### PR TITLE
Multi-Agent DSL Extension

### DIFF
--- a/examples/MultiAgent/2DLivelock.tree
+++ b/examples/MultiAgent/2DLivelock.tree
@@ -1,0 +1,140 @@
+configuration {}
+enumerations {'We', 'Ea', 'No', 'So', 'XX'}
+constants {min_x := 0, max_x := 3, min_y := 0, max_y := 1}
+
+variables {
+    variable { bl act1 VAR {'We', 'Ea', 'No', 'So', 'XX'} assign{result{'XX'}}}
+    variable { bl act2 VAR {'We', 'Ea', 'No', 'So', 'XX'} assign{result{'XX'}}}
+    variable { env x_d1 VAR [min_x, max_x] assign{result{1}}}
+    variable { env y_d1 VAR [min_y, max_y] assign{result{max_y}}}
+    variable { env x_d2 VAR [min_x, max_x] assign{result{2}}}
+    variable { env y_d2 VAR [min_y, max_y] assign{result{max_y}}}
+}
+
+environment_update {
+    variable_statement { x_d1
+        assign {
+            case {(eq, act1, 'Ea')} result {(min, max_x, (add, x_d1, 1))}
+            case {(eq, act1, 'We')} result {(max, min_x, (sub, x_d1, 1))}
+            result {x_d1}}}
+    variable_statement { y_d1
+        assign {
+            case {(eq, act1, 'No')} result {(min, max_y, (add, y_d1, 1))}
+            case {(eq, act1, 'So')} result {(max, min_y, (sub, y_d1, 1))}
+            result {y_d1}}}
+    variable_statement { x_d2
+        assign {
+            case {(eq, act2, 'Ea')} result {(min, max_x, (add, x_d2, 1))}
+            case {(eq, act2, 'We')} result {(max, min_x, (sub, x_d2, 1))}
+            result {x_d2}}}
+    variable_statement { y_d2
+        assign {
+            case {(eq, act2, 'No')} result {(min, max_y, (add, y_d2, 1))}
+            case {(eq, act2, 'So')} result {(max, min_y, (sub, y_d2, 1))}
+            result {y_d2}}}
+}
+
+checks {}
+
+environment_checks {
+    environment_check { AtGoal1
+        arguments {} read_variables {x_d1, y_d1}
+        condition {(and, (eq, x_d1, max_x), (eq, y_d1, max_y))}}
+    environment_check { AtGoal2
+        arguments {} read_variables {x_d2, y_d2}
+        condition {(and, (eq, x_d2, min_x), (eq, y_d2, max_y))}}
+    environment_check { PathClear1
+        arguments {} read_variables {x_d1, y_d1, x_d2, y_d2}
+        condition {(not, (and, (eq, x_d2, (add, x_d1, 1)), (eq, y_d2, y_d1)))}}
+    environment_check { PathClear2
+        arguments {} read_variables {x_d1, y_d1, x_d2, y_d2}
+        condition {(not, (and, (eq, x_d1, (sub, x_d2, 1)), (eq, y_d1, y_d2)))}}
+    environment_check { OnUpperRow1
+        arguments {} read_variables {y_d1}
+        condition {(gt, y_d1, min_y)}}
+    environment_check { OnUpperRow2
+        arguments {} read_variables {y_d2}
+        condition {(gt, y_d2, min_y)}}
+}
+
+actions {
+    action { MoveForward1
+        arguments {} local_variables {} read_variables {} write_variables {act1}
+        initial_values {}
+        update {
+            variable_statement {act1 assign{result{'Ea'}}}
+            return_statement {result{success}}
+        }
+    }
+    action { MoveForward2
+        arguments {} local_variables {} read_variables {} write_variables {act2}
+        initial_values {}
+        update {
+            variable_statement {act2 assign{result{'We'}}}
+            return_statement {result{success}}
+        }
+    }
+    action { StepSouth1
+        arguments {} local_variables {} read_variables {} write_variables {act1}
+        initial_values {}
+        update {
+            variable_statement {act1 assign{result{'So'}}}
+            return_statement {result{success}}
+        }
+    }
+    action { StepNorth1
+        arguments {} local_variables {} read_variables {} write_variables {act1}
+        initial_values {}
+        update {
+            variable_statement {act1 assign{result{'No'}}}
+            return_statement {result{success}}
+        }
+    }
+    action { StepSouth2
+        arguments {} local_variables {} read_variables {} write_variables {act2}
+        initial_values {}
+        update {
+            variable_statement {act2 assign{result{'So'}}}
+            return_statement {result{success}}
+        }
+    }
+    action { StepNorth2
+        arguments {} local_variables {} read_variables {} write_variables {act2}
+        initial_values {}
+        update {
+            variable_statement {act2 assign{result{'No'}}}
+            return_statement {result{success}}
+        }
+    }
+}
+
+sub_trees {}
+
+tree {
+    composite { Root parallel policy success_on_all children {
+        composite { Robot1 selector children {
+            AtGoal1 {}
+            composite { TryForward1 sequence children { PathClear1 {} MoveForward1 {} }}
+            composite { Sidestep1 selector children {
+                composite { SidestepSouth1 sequence children { OnUpperRow1 {} StepSouth1 {} }}
+                StepNorth1 {}
+            }}
+        }}
+        composite { Robot2 selector children {
+            AtGoal2 {}
+            composite { TryForward2 sequence children { PathClear2 {} MoveForward2 {} }}
+            composite { Sidestep2 selector children {
+                composite { SidestepSouth2 sequence children { OnUpperRow2 {} StepSouth2 {} }}
+                StepNorth2 {}
+            }}
+        }}
+    }}
+}
+
+tick_prerequisite {(True)}
+
+specifications {
+    CTLSPEC {(always_globally, (always_finally, (and, (eq, x_d1 at -1, max_x), (eq, y_d1 at -1, max_y))))}
+    CTLSPEC {(always_globally, (always_finally, (and, (eq, x_d2 at -1, min_x), (eq, y_d2 at -1, max_y))))}
+    CTLSPEC {(always_globally, (exists_finally, (and, (eq, x_d1 at -1, max_x), (eq, y_d1 at -1, max_y))))}
+}

--- a/examples/MultiAgent/FiveInRing.tree
+++ b/examples/MultiAgent/FiveInRing.tree
@@ -1,0 +1,327 @@
+configuration {}
+enumerations {'Move', 'Stay'}
+constants {num_pos := 6}
+
+variables {
+    variable { bl act0 VAR {'Move', 'Stay'} assign{result{'Stay'}}}
+    variable { bl act1 VAR {'Move', 'Stay'} assign{result{'Stay'}}}
+    variable { bl act2 VAR {'Move', 'Stay'} assign{result{'Stay'}}}
+    variable { bl act3 VAR {'Move', 'Stay'} assign{result{'Stay'}}}
+    variable { bl act4 VAR {'Move', 'Stay'} assign{result{'Stay'}}}
+    variable { env x_pos0 VAR [0, 5] assign{result{0}}}
+    variable { env x_pos1 VAR [0, 5] assign{result{1}}}
+    variable { env x_pos2 VAR [0, 5] assign{result{2}}}
+    variable { env x_pos3 VAR [0, 5] assign{result{3}}}
+    variable { env x_pos4 VAR [0, 5] assign{result{4}}}
+}
+
+environment_update {
+    variable_statement { x_pos0
+        assign {
+            case {(eq, act0, 'Move')} result {(mod, (add, x_pos0, 1), num_pos)}
+            result {x_pos0}
+        }
+    }
+    variable_statement { x_pos1
+        assign {
+            case {(eq, act1, 'Move')} result {(mod, (add, x_pos1, 1), num_pos)}
+            result {x_pos1}
+        }
+    }
+    variable_statement { x_pos2
+        assign {
+            case {(eq, act2, 'Move')} result {(mod, (add, x_pos2, 1), num_pos)}
+            result {x_pos2}
+        }
+    }
+    variable_statement { x_pos3
+        assign {
+            case {(eq, act3, 'Move')} result {(mod, (add, x_pos3, 1), num_pos)}
+            result {x_pos3}
+        }
+    }
+    variable_statement { x_pos4
+        assign {
+            case {(eq, act4, 'Move')} result {(mod, (add, x_pos4, 1), num_pos)}
+            result {x_pos4}
+        }
+    }
+}
+
+checks {}
+
+environment_checks {
+    #{  Goals: r0->3, r1->4, r2->5, r3->0, r4->5 (one hop, parks at free slot) }#
+    environment_check { AtGoal0
+        arguments {} read_variables {x_pos0}
+        condition {(eq, x_pos0, 3)}}
+    environment_check { AtGoal1
+        arguments {} read_variables {x_pos1}
+        condition {(eq, x_pos1, 4)}}
+    environment_check { AtGoal2
+        arguments {} read_variables {x_pos2}
+        condition {(eq, x_pos2, 5)}}
+    environment_check { AtGoal3
+        arguments {} read_variables {x_pos3}
+        condition {(eq, x_pos3, 0)}}
+    environment_check { AtGoal4
+        arguments {} read_variables {x_pos4}
+        condition {(eq, x_pos4, 5)}}
+    #{  PathClear: next clockwise position must be free of all four other robots.
+        or is variadic in BehaVerify so all four checks fit in one (or, ...). }#
+    environment_check { PathClear0
+        arguments {} read_variables {x_pos0, x_pos1, x_pos2, x_pos3, x_pos4}
+        condition {(not, (or,
+            (eq, x_pos1, (mod, (add, x_pos0, 1), num_pos)),
+            (eq, x_pos2, (mod, (add, x_pos0, 1), num_pos)),
+            (eq, x_pos3, (mod, (add, x_pos0, 1), num_pos)),
+            (eq, x_pos4, (mod, (add, x_pos0, 1), num_pos))))}}
+    environment_check { PathClear1
+        arguments {} read_variables {x_pos0, x_pos1, x_pos2, x_pos3, x_pos4}
+        condition {(not, (or,
+            (eq, x_pos0, (mod, (add, x_pos1, 1), num_pos)),
+            (eq, x_pos2, (mod, (add, x_pos1, 1), num_pos)),
+            (eq, x_pos3, (mod, (add, x_pos1, 1), num_pos)),
+            (eq, x_pos4, (mod, (add, x_pos1, 1), num_pos))))}}
+    environment_check { PathClear2
+        arguments {} read_variables {x_pos0, x_pos1, x_pos2, x_pos3, x_pos4}
+        condition {(not, (or,
+            (eq, x_pos0, (mod, (add, x_pos2, 1), num_pos)),
+            (eq, x_pos1, (mod, (add, x_pos2, 1), num_pos)),
+            (eq, x_pos3, (mod, (add, x_pos2, 1), num_pos)),
+            (eq, x_pos4, (mod, (add, x_pos2, 1), num_pos))))}}
+    environment_check { PathClear3
+        arguments {} read_variables {x_pos0, x_pos1, x_pos2, x_pos3, x_pos4}
+        condition {(not, (or,
+            (eq, x_pos0, (mod, (add, x_pos3, 1), num_pos)),
+            (eq, x_pos1, (mod, (add, x_pos3, 1), num_pos)),
+            (eq, x_pos2, (mod, (add, x_pos3, 1), num_pos)),
+            (eq, x_pos4, (mod, (add, x_pos3, 1), num_pos))))}}
+    environment_check { PathClear4
+        arguments {} read_variables {x_pos0, x_pos1, x_pos2, x_pos3, x_pos4}
+        condition {(not, (or,
+            (eq, x_pos0, (mod, (add, x_pos4, 1), num_pos)),
+            (eq, x_pos1, (mod, (add, x_pos4, 1), num_pos)),
+            (eq, x_pos2, (mod, (add, x_pos4, 1), num_pos)),
+            (eq, x_pos3, (mod, (add, x_pos4, 1), num_pos))))}}
+}
+
+actions {
+    action { Move0
+        arguments {} local_variables {} read_variables {} write_variables {act0}
+        initial_values {}
+        update {
+            variable_statement {act0 assign{result{'Move'}}}
+            return_statement {result{success}}
+        }
+    }
+    action { Move1
+        arguments {} local_variables {} read_variables {} write_variables {act1}
+        initial_values {}
+        update {
+            variable_statement {act1 assign{result{'Move'}}}
+            return_statement {result{success}}
+        }
+    }
+    action { Move2
+        arguments {} local_variables {} read_variables {} write_variables {act2}
+        initial_values {}
+        update {
+            variable_statement {act2 assign{result{'Move'}}}
+            return_statement {result{success}}
+        }
+    }
+    action { Move3
+        arguments {} local_variables {} read_variables {} write_variables {act3}
+        initial_values {}
+        update {
+            variable_statement {act3 assign{result{'Move'}}}
+            return_statement {result{success}}
+        }
+    }
+    action { Move4
+        arguments {} local_variables {} read_variables {} write_variables {act4}
+        initial_values {}
+        update {
+            variable_statement {act4 assign{result{'Move'}}}
+            return_statement {result{success}}
+        }
+    }
+    action { SetStayGoal0
+        arguments {} local_variables {} read_variables {} write_variables {act0}
+        initial_values {}
+        update {
+            variable_statement {act0 assign{result{'Stay'}}}
+            return_statement {result{success}}
+        }
+    }
+    action { SetStayGoal1
+        arguments {} local_variables {} read_variables {} write_variables {act1}
+        initial_values {}
+        update {
+            variable_statement {act1 assign{result{'Stay'}}}
+            return_statement {result{success}}
+        }
+    }
+    action { SetStayGoal2
+        arguments {} local_variables {} read_variables {} write_variables {act2}
+        initial_values {}
+        update {
+            variable_statement {act2 assign{result{'Stay'}}}
+            return_statement {result{success}}
+        }
+    }
+    action { SetStayGoal3
+        arguments {} local_variables {} read_variables {} write_variables {act3}
+        initial_values {}
+        update {
+            variable_statement {act3 assign{result{'Stay'}}}
+            return_statement {result{success}}
+        }
+    }
+    action { SetStayGoal4
+        arguments {} local_variables {} read_variables {} write_variables {act4}
+        initial_values {}
+        update {
+            variable_statement {act4 assign{result{'Stay'}}}
+            return_statement {result{success}}
+        }
+    }
+    action { SetStayWait0
+        arguments {} local_variables {} read_variables {} write_variables {act0}
+        initial_values {}
+        update {
+            variable_statement {act0 assign{result{'Stay'}}}
+            return_statement {result{success}}
+        }
+    }
+    action { SetStayWait1
+        arguments {} local_variables {} read_variables {} write_variables {act1}
+        initial_values {}
+        update {
+            variable_statement {act1 assign{result{'Stay'}}}
+            return_statement {result{success}}
+        }
+    }
+    action { SetStayWait2
+        arguments {} local_variables {} read_variables {} write_variables {act2}
+        initial_values {}
+        update {
+            variable_statement {act2 assign{result{'Stay'}}}
+            return_statement {result{success}}
+        }
+    }
+    action { SetStayWait3
+        arguments {} local_variables {} read_variables {} write_variables {act3}
+        initial_values {}
+        update {
+            variable_statement {act3 assign{result{'Stay'}}}
+            return_statement {result{success}}
+        }
+    }
+    action { SetStayWait4
+        arguments {} local_variables {} read_variables {} write_variables {act4}
+        initial_values {}
+        update {
+            variable_statement {act4 assign{result{'Stay'}}}
+            return_statement {result{success}}
+        }
+    }
+}
+
+sub_trees {}
+
+tree {
+    composite { Root parallel policy success_on_all children {
+        composite { Robot0 selector children {
+            composite { AtGoalSeq0 sequence children {
+                AtGoal0 {}
+                SetStayGoal0 {}
+            }}
+            composite { TryMove0 sequence children {
+                PathClear0 {}
+                Move0 {}
+            }}
+            SetStayWait0 {}
+        }}
+        composite { Robot1 selector children {
+            composite { AtGoalSeq1 sequence children {
+                AtGoal1 {}
+                SetStayGoal1 {}
+            }}
+            composite { TryMove1 sequence children {
+                PathClear1 {}
+                Move1 {}
+            }}
+            SetStayWait1 {}
+        }}
+        composite { Robot2 selector children {
+            composite { AtGoalSeq2 sequence children {
+                AtGoal2 {}
+                SetStayGoal2 {}
+            }}
+            composite { TryMove2 sequence children {
+                PathClear2 {}
+                Move2 {}
+            }}
+            SetStayWait2 {}
+        }}
+        composite { Robot3 selector children {
+            composite { AtGoalSeq3 sequence children {
+                AtGoal3 {}
+                SetStayGoal3 {}
+            }}
+            composite { TryMove3 sequence children {
+                PathClear3 {}
+                Move3 {}
+            }}
+            SetStayWait3 {}
+        }}
+        composite { Robot4 selector children {
+            composite { AtGoalSeq4 sequence children {
+                AtGoal4 {}
+                SetStayGoal4 {}
+            }}
+            composite { TryMove4 sequence children {
+                PathClear4 {}
+                Move4 {}
+            }}
+            SetStayWait4 {}
+        }}
+    }}
+}
+
+tick_prerequisite {(True)}
+
+specifications {
+    #{  Safety: no two robots occupy the same position (C(5,2) = 10 pairs) }#
+    INVARSPEC {(and,
+        (neq, x_pos0 at -1, x_pos1 at -1),
+        (neq, x_pos0 at -1, x_pos2 at -1),
+        (neq, x_pos0 at -1, x_pos3 at -1),
+        (neq, x_pos0 at -1, x_pos4 at -1),
+        (neq, x_pos1 at -1, x_pos2 at -1),
+        (neq, x_pos1 at -1, x_pos3 at -1),
+        (neq, x_pos1 at -1, x_pos4 at -1),
+        (neq, x_pos2 at -1, x_pos3 at -1),
+        (neq, x_pos2 at -1, x_pos4 at -1),
+        (neq, x_pos3 at -1, x_pos4 at -1))}
+
+    #{  AG AF: robots always eventually reach their goals
+        r0->3, r1->4, r2->5, r3->0 expected FALSE (deadlocked after tick 5)
+        r4->5 expected TRUE (reaches goal at tick 0, parks permanently) }#
+    CTLSPEC {(always_globally, (always_finally, (eq, x_pos0 at -1, 3)))}
+    CTLSPEC {(always_globally, (always_finally, (eq, x_pos1 at -1, 4)))}
+    CTLSPEC {(always_globally, (always_finally, (eq, x_pos2 at -1, 5)))}
+    CTLSPEC {(always_globally, (always_finally, (eq, x_pos3 at -1, 0)))}
+    CTLSPEC {(always_globally, (always_finally, (eq, x_pos4 at -1, 5)))}
+
+    #{  AG EF: from every state each robot can eventually reach its goal
+        All four blocked robots expected FALSE — r4 permanently occupies position 5,
+        stranding r2 (whose goal is 5) and r3 (whose path passes through 5),
+        which in turn block r1 then r0. No execution path escapes the deadlock. }#
+    CTLSPEC {(always_globally, (exists_finally, (eq, x_pos0 at -1, 3)))}
+    CTLSPEC {(always_globally, (exists_finally, (eq, x_pos1 at -1, 4)))}
+    CTLSPEC {(always_globally, (exists_finally, (eq, x_pos2 at -1, 5)))}
+    CTLSPEC {(always_globally, (exists_finally, (eq, x_pos3 at -1, 0)))}
+}

--- a/examples/MultiAgent/ThreeInRing.tree
+++ b/examples/MultiAgent/ThreeInRing.tree
@@ -1,0 +1,217 @@
+configuration {}
+enumerations {'Move', 'Stay'}
+constants {num_pos := 4}
+
+variables {
+    variable { bl act0 VAR {'Move', 'Stay'} assign{result{'Stay'}}}
+    variable { bl act1 VAR {'Move', 'Stay'} assign{result{'Stay'}}}
+    variable { bl act2 VAR {'Move', 'Stay'} assign{result{'Stay'}}}
+    variable { env x_pos0 VAR [0, 3] assign{result{0}}}
+    variable { env x_pos1 VAR [0, 3] assign{result{1}}}
+    variable { env x_pos2 VAR [0, 3] assign{result{2}}}
+}
+
+environment_update {
+    variable_statement { x_pos0
+        assign {
+            case {(eq, act0, 'Move')} result {(mod, (add, x_pos0, 1), num_pos)}
+            result {x_pos0}
+        }
+    }
+    variable_statement { x_pos1
+        assign {
+            case {(eq, act1, 'Move')} result {(mod, (add, x_pos1, 1), num_pos)}
+            result {x_pos1}
+        }
+    }
+    variable_statement { x_pos2
+        assign {
+            case {(eq, act2, 'Move')} result {(mod, (add, x_pos2, 1), num_pos)}
+            result {x_pos2}
+        }
+    }
+}
+
+checks {}
+
+environment_checks {
+    #{  r0: starts at 0, goal at 2 }#
+    environment_check { AtGoal0
+        arguments {} read_variables {x_pos0}
+        condition {(eq, x_pos0, 2)}}
+    #{  r1: starts at 1, goal at 0 (full loop: 1->2->3->0) }#
+    environment_check { AtGoal1
+        arguments {} read_variables {x_pos1}
+        condition {(eq, x_pos1, 0)}}
+    #{  r2: starts at 2, goal at 3 (one hop) }#
+    environment_check { AtGoal2
+        arguments {} read_variables {x_pos2}
+        condition {(eq, x_pos2, 3)}}
+    #{  PathClear: next clockwise position must be free of both other robots }#
+    environment_check { PathClear0
+        arguments {} read_variables {x_pos0, x_pos1, x_pos2}
+        condition {(not, (or,
+            (eq, x_pos1, (mod, (add, x_pos0, 1), num_pos)),
+            (eq, x_pos2, (mod, (add, x_pos0, 1), num_pos))))}}
+    environment_check { PathClear1
+        arguments {} read_variables {x_pos0, x_pos1, x_pos2}
+        condition {(not, (or,
+            (eq, x_pos0, (mod, (add, x_pos1, 1), num_pos)),
+            (eq, x_pos2, (mod, (add, x_pos1, 1), num_pos))))}}
+    environment_check { PathClear2
+        arguments {} read_variables {x_pos0, x_pos1, x_pos2}
+        condition {(not, (or,
+            (eq, x_pos0, (mod, (add, x_pos2, 1), num_pos)),
+            (eq, x_pos1, (mod, (add, x_pos2, 1), num_pos))))}}
+}
+
+actions {
+    action { Move0
+        arguments {} local_variables {} read_variables {} write_variables {act0}
+        initial_values {}
+        update {
+            variable_statement {act0 assign{result{'Move'}}}
+            return_statement {result{success}}
+        }
+    }
+    action { Move1
+        arguments {} local_variables {} read_variables {} write_variables {act1}
+        initial_values {}
+        update {
+            variable_statement {act1 assign{result{'Move'}}}
+            return_statement {result{success}}
+        }
+    }
+    action { Move2
+        arguments {} local_variables {} read_variables {} write_variables {act2}
+        initial_values {}
+        update {
+            variable_statement {act2 assign{result{'Move'}}}
+            return_statement {result{success}}
+        }
+    }
+    #{  SetStayGoal: resets act to Stay when robot reaches goal, preventing
+        the environment_update from advancing it past its goal on the next tick. }#
+    action { SetStayGoal0
+        arguments {} local_variables {} read_variables {} write_variables {act0}
+        initial_values {}
+        update {
+            variable_statement {act0 assign{result{'Stay'}}}
+            return_statement {result{success}}
+        }
+    }
+    action { SetStayGoal1
+        arguments {} local_variables {} read_variables {} write_variables {act1}
+        initial_values {}
+        update {
+            variable_statement {act1 assign{result{'Stay'}}}
+            return_statement {result{success}}
+        }
+    }
+    action { SetStayGoal2
+        arguments {} local_variables {} read_variables {} write_variables {act2}
+        initial_values {}
+        update {
+            variable_statement {act2 assign{result{'Stay'}}}
+            return_statement {result{success}}
+        }
+    }
+    #{  SetStayWait: fallback when PathClear fails (robot is blocked). Explicitly
+        resets act to Stay so a stale Move from a prior tick does not advance
+        the robot through the environment_update. }#
+    action { SetStayWait0
+        arguments {} local_variables {} read_variables {} write_variables {act0}
+        initial_values {}
+        update {
+            variable_statement {act0 assign{result{'Stay'}}}
+            return_statement {result{success}}
+        }
+    }
+    action { SetStayWait1
+        arguments {} local_variables {} read_variables {} write_variables {act1}
+        initial_values {}
+        update {
+            variable_statement {act1 assign{result{'Stay'}}}
+            return_statement {result{success}}
+        }
+    }
+    action { SetStayWait2
+        arguments {} local_variables {} read_variables {} write_variables {act2}
+        initial_values {}
+        update {
+            variable_statement {act2 assign{result{'Stay'}}}
+            return_statement {result{success}}
+        }
+    }
+}
+
+sub_trees {}
+
+tree {
+    composite { Root parallel policy success_on_all children {
+        composite { Robot0 selector children {
+            composite { AtGoalSeq0 sequence children {
+                AtGoal0 {}
+                SetStayGoal0 {}
+            }}
+            composite { TryMove0 sequence children {
+                PathClear0 {}
+                Move0 {}
+            }}
+            SetStayWait0 {}
+        }}
+        composite { Robot1 selector children {
+            composite { AtGoalSeq1 sequence children {
+                AtGoal1 {}
+                SetStayGoal1 {}
+            }}
+            composite { TryMove1 sequence children {
+                PathClear1 {}
+                Move1 {}
+            }}
+            SetStayWait1 {}
+        }}
+        composite { Robot2 selector children {
+            composite { AtGoalSeq2 sequence children {
+                AtGoal2 {}
+                SetStayGoal2 {}
+            }}
+            composite { TryMove2 sequence children {
+                PathClear2 {}
+                Move2 {}
+            }}
+            SetStayWait2 {}
+        }}
+    }}
+}
+
+tick_prerequisite {(True)}
+
+specifications {
+    #{  Safety: no two robots occupy the same position }#
+    INVARSPEC {(and,
+        (neq, x_pos0 at -1, x_pos1 at -1),
+        (neq, x_pos1 at -1, x_pos2 at -1),
+        (neq, x_pos0 at -1, x_pos2 at -1))}
+
+    #{  AG AF: r0 always eventually reaches goal 2 — expected FALSE
+        r2 parks at 3 after tick 1, blocking r1; r1 blocks r0 permanently }#
+    CTLSPEC {(always_globally, (always_finally, (eq, x_pos0 at -1, 2)))}
+
+    #{  AG AF: r1 always eventually reaches goal 0 — expected FALSE
+        r1 must pass through 3, but r2 is parked there permanently }#
+    CTLSPEC {(always_globally, (always_finally, (eq, x_pos1 at -1, 0)))}
+
+    #{  AG AF: r2 always eventually reaches goal 3 — expected TRUE
+        r2 is the only robot that can move at tick 0 and reaches its goal
+        immediately, then stays there }#
+    CTLSPEC {(always_globally, (always_finally, (eq, x_pos2 at -1, 3)))}
+
+    #{  AG EF: r0 can eventually reach goal 2 — expected FALSE
+        from the deadlocked state, no execution path leads r0 to 2 }#
+    CTLSPEC {(always_globally, (exists_finally, (eq, x_pos0 at -1, 2)))}
+
+    #{  AG EF: r1 can eventually reach goal 0 — expected FALSE
+        r2 permanently blocks position 3 which r1 must pass through }#
+    CTLSPEC {(always_globally, (exists_finally, (eq, x_pos1 at -1, 0)))}
+}

--- a/examples/MultiAgent/TwoRobot1D.tree
+++ b/examples/MultiAgent/TwoRobot1D.tree
@@ -1,0 +1,70 @@
+configuration {}
+enumerations {'We', 'Ea', 'XX'}
+constants {min_val := 0, max_val := 4}
+
+variables {
+    variable { bl act1 VAR {'We', 'Ea', 'XX'} assign{result{'XX'}}}
+    variable { bl act2 VAR {'We', 'Ea', 'XX'} assign{result{'XX'}}}
+    variable { env x_d1 VAR [min_val, max_val] assign{result{min_val}}}
+    variable { env x_d2 VAR [min_val, max_val] assign{result{max_val}}}
+}
+
+environment_update {
+    variable_statement { x_d1
+        assign {
+            case {(eq, act1, 'We')} result {(max, min_val, (sub, x_d1, 1))}
+            case {(eq, act1, 'Ea')} result {(min, max_val, (add, x_d1, 1))}
+            result {x_d1}}}
+    variable_statement { x_d2
+        assign {
+            case {(eq, act2, 'We')} result {(max, min_val, (sub, x_d2, 1))}
+            case {(eq, act2, 'Ea')} result {(min, max_val, (add, x_d2, 1))}
+            result {x_d2}}}
+}
+
+checks {}
+
+environment_checks {
+    environment_check { AtGoal1
+        arguments {} read_variables {x_d1}
+        condition {(eq, x_d1, max_val)}}
+    environment_check { AtGoal2
+        arguments {} read_variables {x_d2}
+        condition {(eq, x_d2, min_val)}}
+}
+
+actions {
+    action { Move1
+        arguments {} local_variables {} read_variables {} write_variables {act1}
+        initial_values {}
+        update {
+            variable_statement {act1 assign{result{'We', 'Ea'}}}
+            return_statement {result{success}}
+        }
+    }
+    action { Move2
+        arguments {} local_variables {} read_variables {} write_variables {act2}
+        initial_values {}
+        update {
+            variable_statement {act2 assign{result{'We', 'Ea'}}}
+            return_statement {result{success}}
+        }
+    }
+}
+
+sub_trees {}
+
+tree {
+    composite { Root parallel policy success_on_all children {
+        composite { Robot1 selector children { AtGoal1 {} Move1 {} }}
+        composite { Robot2 selector children { AtGoal2 {} Move2 {} }}
+    }}
+}
+
+tick_prerequisite {(True)}
+
+specifications {
+    INVARSPEC {(not, (eq, x_d1 at -1, x_d2 at -1))}
+    CTLSPEC {(always_globally, (exists_finally, (eq, x_d1 at -1, max_val)))}
+    CTLSPEC {(always_globally, (exists_finally, (eq, x_d2 at -1, min_val)))}
+}

--- a/examples/MultiAgent/visualize_livelock.py
+++ b/examples/MultiAgent/visualize_livelock.py
@@ -1,0 +1,114 @@
+#!/usr/bin/env python3
+"""Visualize the 2DLivelock counterexample trace from nuXmv output.
+
+Usage:
+    python3 visualize_livelock.py [nuxmv_output_file]
+    python3 visualize_livelock.py output/nuxmv/2DLivelock_output.txt
+"""
+import sys
+import re
+
+MAX_X, MAX_Y = 3, 1
+GOAL1 = (MAX_X, MAX_Y)   # R1 goal: (3, 1)
+GOAL2 = (0,    MAX_Y)    # R2 goal: (0, 1)
+
+
+def parse_first_trace(path):
+    """Extract per-state variable values from the first counterexample in the file."""
+    states = []
+    loop_at = None
+    in_trace = False
+    current = {}
+
+    with open(path) as f:
+        for line in f:
+            s = line.strip()
+
+            if '-- specification' in s and 'is false' in s:
+                in_trace = True
+                continue
+            if not in_trace:
+                continue
+            if '-- specification' in s:   # next spec result -- stop
+                break
+            if '-- Loop starts here' in s:
+                loop_at = len(states)      # next appended state starts the loop
+                continue
+            if s.startswith('-> State:'):
+                if current:
+                    states.append(current.copy())
+                current = {}
+                continue
+
+            m = re.match(r'system\.(\w+)_stage_(\d+)\s*=\s*(-?\w+)', s)
+            if m:
+                var, stage, val = m.group(1), int(m.group(2)), m.group(3)
+                if var in ('x_d1', 'y_d1', 'x_d2', 'y_d2'):
+                    current[(var, stage)] = int(val)
+
+    if current:
+        states.append(current.copy())
+    return states, loop_at
+
+
+def resolve(raw_states):
+    """Carry forward stage_1 values; fall back to stage_0 for initial state."""
+    resolved = []
+    last = {}
+    for raw in raw_states:
+        pos = dict(last)
+        for var in ('x_d1', 'y_d1', 'x_d2', 'y_d2'):
+            if (var, 1) in raw:
+                pos[var] = raw[(var, 1)]
+            elif (var, 0) in raw and var not in pos:
+                pos[var] = raw[(var, 0)]
+        last = pos
+        resolved.append(pos)
+    return resolved
+
+
+def draw(pos):
+    r1 = (pos.get('x_d1'), pos.get('y_d1'))
+    r2 = (pos.get('x_d2'), pos.get('y_d2'))
+
+    cells = {GOAL1: 'G1', GOAL2: 'G2'}
+    if None not in r1 and None not in r2:
+        if r1 == r2:
+            cells[r1] = 'XX'
+        else:
+            cells[r1] = 'R1'
+            cells[r2] = 'R2'
+
+    for y in range(MAX_Y, -1, -1):
+        row = f'  y={y} '
+        for x in range(MAX_X + 1):
+            row += '[{:2}]'.format(cells.get((x, y), '  '))
+        print(row)
+    print('       ' + '    '.join(f'x={x}' for x in range(MAX_X + 1)))
+
+
+def main():
+    path = sys.argv[1] if len(sys.argv) > 1 else 'output/nuxmv/2DLivelock_output.txt'
+    raw_states, loop_at = parse_first_trace(path)
+    states = resolve(raw_states)
+
+    if not states:
+        print(f'No counterexample found in {path}')
+        return
+
+    print('2D Livelock Trace Visualization')
+    print(f'R1: (1,1) -> goal G1={GOAL1}   R2: (2,1) -> goal G2={GOAL2}')
+    print('Legend: R1/R2=robots  G1/G2=goals  XX=collision  (blank)=empty\n')
+
+    for i, pos in enumerate(states):
+        if loop_at is not None and i == loop_at:
+            print('  *** LOOP STARTS HERE -- livelock cycle ***\n')
+        r1 = (pos.get('x_d1'), pos.get('y_d1'))
+        r2 = (pos.get('x_d2'), pos.get('y_d2'))
+        print(f'State {i + 1}:  R1={r1}  R2={r2}')
+        draw(pos)
+        print()
+
+
+if __name__ == '__main__':
+    main()

--- a/src/behaverify/agent_expander.py
+++ b/src/behaverify/agent_expander.py
@@ -1,0 +1,1190 @@
+"""
+agent_expander.py — Pre-processing pass for multi-agent BehaVerify models.
+
+When a .tree file contains agent_types { } and agents { } blocks, this module
+expands the templates into a flat single-agent model that the existing pipeline
+(dsl_to_nuxmv, dsl_to_python, etc.) can process unchanged.
+
+The expansion strategy ("expand early, not deep"):
+  1. Parse the multi-agent .tree file with the extended grammar.
+  2. Expand:
+     - env array variables (x_pos[agents]) → x_pos_r0, x_pos_r1, …
+     - agent-local bl variables (act) → act_r0, act_r1, …
+     - environment_update [i] loops → N concrete statements
+     - agent_type templates → concrete checks, actions, subtrees per instance
+     - forall/exists over agents in specifications → conjunctions/disjunctions
+  3. Return an ExpandedModel object whose model_to_tree_text() produces
+     valid standard .tree text that the existing pipeline accepts.
+
+Public API:
+    expand_agents(model)          -> ExpandedModel
+    model_to_tree_text(expanded)  -> str
+    maybe_expand(file_path)       -> str (original or temp-file path)
+"""
+
+import re
+import os
+import tempfile
+from pathlib import Path
+
+
+# ---------------------------------------------------------------------------
+# ExpandedModel data classes
+# ---------------------------------------------------------------------------
+
+class ExpandedVariable:
+    """A single variable in the expanded flat model."""
+    def __init__(self, name, scope, domain_text, initial_value=None, initial_text=None):
+        self.name = name
+        self.scope = scope            # 'bl', 'env', or 'local'
+        self.domain_text = domain_text  # e.g. "{'We','Ea','XX'}" or "[0, 4]"
+        self.initial_value = initial_value  # numeric/string for simple scalars
+        self.initial_text = initial_text    # raw .tree assign text if complex
+
+    def to_tree_text(self):
+        if self.initial_text:
+            assign = self.initial_text
+        elif isinstance(self.initial_value, str):
+            assign = f"assign{{result{{'{self.initial_value}'}}}}"
+        else:
+            assign = f"assign{{result{{{self.initial_value}}}}}"
+        return f"variable {{ {self.scope} {self.name} VAR {self.domain_text} {assign}}}"
+
+
+class ExpandedCheck:
+    """A single environment_check in the expanded model."""
+    def __init__(self, name, condition_text, read_vars=None):
+        self.name = name
+        self.condition_text = condition_text
+        self.read_vars = read_vars or []
+
+    def to_tree_text(self):
+        rv = ', '.join(self.read_vars) if self.read_vars else ''
+        return (
+            f"environment_check {{ {self.name}\n"
+            f"        arguments {{}} read_variables {{{rv}}}\n"
+            f"        condition {{{self.condition_text}}}}}"
+        )
+
+
+class ExpandedAction:
+    """A single action in the expanded model."""
+    def __init__(self, name, write_vars, update_text):
+        self.name = name
+        self.write_vars = write_vars  # list of var names
+        self.update_text = update_text  # raw .tree update body text
+
+    def to_tree_text(self):
+        wv = ', '.join(self.write_vars)
+        return (
+            f"action {{ {self.name}\n"
+            f"        arguments {{}} local_variables {{}} read_variables {{}}"
+            f" write_variables {{{wv}}}\n"
+            f"        initial_values {{}}\n"
+            f"        update {{\n"
+            f"            {self.update_text}\n"
+            f"        }}}}"
+        )
+
+
+class ExpandedSpec:
+    """A single specification (INVARSPEC / CTLSPEC / LTLSPEC)."""
+    def __init__(self, spec_type, body_text):
+        self.spec_type = spec_type
+        self.body_text = body_text
+
+    def __str__(self):
+        return f"{self.spec_type} {{{self.body_text}}}"
+
+
+class ExpandedTreeNode:
+    """A node in the expanded behavior tree."""
+    def __init__(self, node_type, name, children=None, leaf_name=None,
+                 parallel_policy='success_on_all'):
+        self.node_type = node_type    # 'parallel', 'selector', 'sequence', 'leaf'
+        self.name = name
+        self.children = children or []
+        self.leaf_name = leaf_name    # for leaf nodes: name of check/action
+        self.parallel_policy = parallel_policy
+
+    def to_tree_text(self, indent=4):
+        pad = ' ' * indent
+        if self.node_type == 'leaf':
+            return f"{pad}{self.leaf_name} {{}}"
+        elif self.node_type == 'parallel':
+            child_text = '\n'.join(c.to_tree_text(indent + 4) for c in self.children)
+            return (
+                f"{pad}composite {{ {self.name} parallel policy"
+                f" {self.parallel_policy} children {{\n"
+                f"{child_text}\n"
+                f"{pad}}}}}"
+            )
+        else:
+            child_text = '\n'.join(c.to_tree_text(indent + 4) for c in self.children)
+            return (
+                f"{pad}composite {{ {self.name} {self.node_type} children {{\n"
+                f"{child_text}\n"
+                f"{pad}}}}}"
+            )
+
+
+class ExpandedModel:
+    """The fully expanded flat model ready for model_to_tree_text()."""
+    def __init__(self):
+        self.configuration_text = ''
+        self.enumerations = []
+        self.constants_text = ''
+        self.variables = []             # list of ExpandedVariable
+        self.environment_update_text = ''
+        self.check_nodes = []
+        self.environment_checks = []    # list of ExpandedCheck
+        self.action_nodes = []          # list of ExpandedAction
+        self.sub_trees_text = ''
+        self.tree = None                # ExpandedTreeNode (root)
+        self.tick_prerequisite_text = '(True)'
+        self.specifications = []        # list of ExpandedSpec
+        self.agent_types = []           # always empty after expansion
+
+
+# ---------------------------------------------------------------------------
+# Helper: resolve constants from model
+# ---------------------------------------------------------------------------
+
+def _resolve_constants(model):
+    """Return a dict of constant name -> numeric or string value."""
+    consts = {}
+    for c in model.constants:
+        val = c.val
+        if hasattr(val, 'val') and val.val is not None:
+            consts[c.name] = val.val
+        elif isinstance(val, (int, float)):
+            consts[c.name] = val
+        else:
+            # Try extracting the raw value
+            raw = str(val)
+            try:
+                consts[c.name] = int(raw)
+            except ValueError:
+                try:
+                    consts[c.name] = float(raw)
+                except ValueError:
+                    consts[c.name] = raw.strip("'\"")
+    return consts
+
+
+def _resolve_value(value_obj, consts):
+    """Resolve a constant_or_reference to a Python value."""
+    if value_obj is None:
+        return None
+    if value_obj.constant is not None:
+        v = value_obj.constant
+        if hasattr(v, 'val') and v.val is not None:
+            return v.val
+        return v
+    if value_obj.reference:
+        ref = value_obj.reference
+        if ref in consts:
+            return consts[ref]
+        return ref
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Helper: code_statement to text (AST serializer)
+# ---------------------------------------------------------------------------
+
+def _cs_to_text(cs):
+    """Convert a code_statement AST node back to .tree expression text."""
+    if cs is None:
+        return 'None'
+
+    # agent_param_ref: agents[i].param_name
+    if cs.agent_param_ref:
+        return f'agents[{cs.agent_param_index}].{cs.agent_param_name}'
+
+    # indexed_var: x_pos[i] or x_pos[i] at -1
+    if cs.indexed_var:
+        txt = f'{cs.indexed_var}[{cs.indexed_var_index}]'
+        if cs.read_at_idx is not None:
+            txt += f' at {_cs_to_text(cs.read_at_idx)}'
+        return txt
+
+    # function_call — wrap in parens to produce valid .tree syntax
+    if cs.function_call:
+        return '(' + _func_to_text(cs.function_call) + ')'
+
+    # nested (code_statement)
+    if cs.code_statement:
+        return f'({_cs_to_text(cs.code_statement)})'
+
+    # atom
+    if cs.atom is not None:
+        atom = cs.atom
+        if atom.constant is not None:
+            v = atom.constant
+            if hasattr(v, 'val') and v.val is not None:
+                raw = str(v.val)
+                # Strings need quoting
+                if isinstance(v.val, str):
+                    return f"'{v.val}'"
+                return raw
+            # TextX returns the primitive value directly for constant_value rules
+            if isinstance(v, str):
+                return f"'{v}'"
+            raw = str(v)
+            return raw
+        if atom.reference:
+            txt = atom.reference
+            if cs.node_name is not None:
+                txt += f' node {_cs_to_text(cs.node_name)}'
+            if cs.read_at is not None:
+                txt += f' at {_cs_to_text(cs.read_at)}'
+            if cs.trace_num is not None:
+                txt += f' trace {_cs_to_text(cs.trace_num)}'
+            return txt
+
+    return 'UNKNOWN'
+
+
+def _func_to_text(func):
+    """Convert a function AST node back to .tree function text (without parens)."""
+    fname = func.function_name
+
+    # loop
+    if fname == 'loop':
+        domain = _loop_domain_text(func)
+        cond = _cs_to_text(func.loop_condition)
+        val = _cs_to_text(func.values)
+        rev = 'reverse ' if func.reverse else ''
+        return f'loop, {func.loop_variable}, {rev}{domain} such_that {cond}, {val}'
+
+    # case_loop
+    if fname == 'case_loop':
+        domain = _loop_domain_text(func)
+        cond = _cs_to_text(func.loop_condition)
+        cv = _cs_to_text(func.cond_value)
+        val = _cs_to_text(func.values)
+        dv = _cs_to_text(func.default_value)
+        rev = 'reverse ' if func.reverse else ''
+        return f'case_loop, {func.loop_variable}, {rev}{domain} such_that {cond}, {cv}, {val}, {dv}'
+
+    # index
+    if fname == 'index':
+        idx = _cs_to_text(func.to_index)
+        ci = 'constant_index ' if func.constant_index == 'constant_index' else ''
+        val = _cs_to_text(func.values)
+        parts = [f'index, {idx}']
+        if func.node_name:
+            parts.append(_cs_to_text(func.node_name))
+        if func.read_at:
+            parts.append(_cs_to_text(func.read_at))
+        if func.trace_num:
+            parts.append(_cs_to_text(func.trace_num))
+        parts.append(f'{ci}{val}')
+        return ', '.join(parts)
+
+    # bounded functions
+    if fname in ('globally_bounded', 'finally_bounded', 'until_bounded',
+                 'release_bounded', 'historically_bounded', 'once_bounded',
+                 'since_bounded', 'triggered_bounded'):
+        lb = _cs_to_text(func.bound.lower_bound)
+        ub = _cs_to_text(func.bound.upper_bound)
+        val = _cs_to_text(func.values)
+        return f'{fname}, [{lb}, {ub}], {val}'
+
+    # status functions
+    if fname in ('active', 'success', 'running', 'failure'):
+        return f'{fname}, {_cs_to_text(func.node_name)}'
+
+    # regular functions (including forall, exists, and, or, etc.)
+    args = ', '.join(_cs_to_text(v) for v in func.values)
+    return f'{fname}, {args}'
+
+
+def _loop_domain_text(func):
+    if func.loop_variable_domain:
+        inner = ', '.join(_cs_to_text(v) for v in func.loop_variable_domain)
+        return f'{{{inner}}}'
+    return f'[{_cs_to_text(func.min_val)}, {_cs_to_text(func.max_val)}]'
+
+
+# ---------------------------------------------------------------------------
+# Helper: assign_value to text
+# ---------------------------------------------------------------------------
+
+def _assign_to_text(assign_val):
+    """Convert assign_value AST back to .tree assign text."""
+    if assign_val is None:
+        return 'assign{result{0}}'
+    parts = []
+    for cr in assign_val.case_results:
+        cond = _cs_to_text(cr.condition)
+        vals = ', '.join(_cs_to_text(v) for v in cr.values)
+        parts.append(f'case {{{cond}}} result {{{vals}}}')
+    dr = assign_val.default_result
+    if dr:
+        vals = ', '.join(_cs_to_text(v) for v in dr.values)
+        parts.append(f'result {{{vals}}}')
+    return 'assign{\n            ' + '\n            '.join(parts) + '}'
+
+
+# ---------------------------------------------------------------------------
+# Substitution helpers
+# ---------------------------------------------------------------------------
+
+def _substitute(text, substitutions):
+    """Apply a dict of {old: new} substitutions to text."""
+    # Sort by length descending to avoid partial matches
+    for old, new in sorted(substitutions.items(), key=lambda x: -len(x[0])):
+        text = text.replace(old, new)
+    return text
+
+
+def _build_agent_subs(agent_name, agent_vars, env_arrays, consts, params):
+    """
+    Build substitution dict for expanding a template to agent 'agent_name'.
+
+    agent_vars  : list of agent-local bl variable base names (e.g. ['act'])
+    env_arrays  : list of env array base names (e.g. ['x_pos'])
+    consts      : {name: value} for constants
+    params      : {param_name: value} for this agent's parameters
+    """
+    subs = {}
+    # [self] → _rN
+    for var in env_arrays:
+        subs[f'{var}[self]'] = f'{var}_{agent_name}'
+    # agent-local vars → suffixed
+    for var in agent_vars:
+        subs[var] = f'{var}_{agent_name}'
+    # parameter names → their resolved values
+    for pname, pval in params.items():
+        if pname in consts:
+            # Already handled via direct value — but also substitute the name
+            pass
+        subs[pname] = str(pval)
+    return subs
+
+
+# ---------------------------------------------------------------------------
+# Core expansion logic
+# ---------------------------------------------------------------------------
+
+def expand_agents(model):
+    """
+    Expand a parsed multi-agent model into a flat ExpandedModel.
+
+    Args:
+        model: TextX-parsed BehaviorModel with agent_types and agents.
+
+    Returns:
+        ExpandedModel ready for model_to_tree_text().
+    """
+    expanded = ExpandedModel()
+
+    # If no agent_types/agents, just wrap original model (pass-through)
+    if not model.agent_types and not model.agents:
+        return _passthrough(model)
+
+    # --- Step 1: resolve constants ---
+    consts = _resolve_constants(model)
+
+    # --- Step 2: parse agent instances and their parameters ---
+    agent_names = []
+    agent_params = {}  # agent_name -> {param_name: resolved_value}
+    for inst in model.agents:
+        name = inst.name
+        agent_names.append(name)
+        params = {}
+        for pa in inst.param_assignments:
+            params[pa.name] = _resolve_value(pa.value, consts)
+        agent_params[name] = params
+
+    # --- Step 3: find env array variables (those with agents_array == 'agents') ---
+    env_arrays = {}   # base_name -> {domain_text, init_param}
+    non_array_vars = []
+
+    for var in model.variables:
+        if var.agents_array == 'agents':
+            domain_text = _domain_to_text(var.domain)
+            # The assign has agents[i].start_x — extract param name from assign text
+            init_param = _extract_agent_param_from_assign(var.assign)
+            env_arrays[var.name] = {
+                'domain_text': domain_text,
+                'init_param': init_param,
+                'scope': var.var_type,
+            }
+        else:
+            non_array_vars.append(var)
+
+    # --- Step 4: get agent_type template ---
+    # We only support one agent type for now
+    at = model.agent_types[0] if model.agent_types else None
+
+    # Agent-local bl variable base names from agent_type
+    agent_local_vars = []
+    if at:
+        for v in at.agent_variables:
+            agent_local_vars.append(v.name)
+
+    # --- Step 5: build expanded variables ---
+    # Non-array top-level variables (pass through)
+    for var in non_array_vars:
+        ev = _expand_variable(var)
+        if ev:
+            expanded.variables.append(ev)
+
+    # Env array variables → one per agent
+    for arr_name, arr_info in env_arrays.items():
+        for agent_name in agent_names:
+            params = agent_params[agent_name]
+            init_param = arr_info['init_param']
+            if init_param and init_param in params:
+                init_val = params[init_param]
+            else:
+                init_val = 0
+            ev = ExpandedVariable(
+                name=f'{arr_name}_{agent_name}',
+                scope=arr_info['scope'],
+                domain_text=arr_info['domain_text'],
+                initial_value=init_val,
+            )
+            expanded.variables.append(ev)
+
+    # Agent-local bl variables → one per agent
+    if at:
+        for v in at.agent_variables:
+            domain_text = _domain_to_text(v.domain)
+            init_text = _assign_to_text(v.assign)
+            for agent_name in agent_names:
+                ev = ExpandedVariable(
+                    name=f'{v.name}_{agent_name}',
+                    scope=v.var_type,
+                    domain_text=domain_text,
+                    initial_text=init_text,
+                )
+                expanded.variables.append(ev)
+
+    # --- Step 6: expand environment_update ---
+    expanded.environment_update_text = _expand_env_update(
+        model, agent_names, env_arrays, agent_local_vars, consts
+    )
+
+    # --- Step 7: pass through top-level checks ---
+    # (model.check_nodes are usually empty in multi-agent files)
+
+    # --- Step 8: expand environment_checks from agent_type template ---
+    if at:
+        for ck in at.agent_environment_checks:
+            for agent_name in agent_names:
+                params = agent_params[agent_name]
+                cond_text = _cs_to_text(ck.condition)
+                # substitute: x_pos[self] → x_pos_rN, goal_x → val, etc.
+                subs = {}
+                for arr_name in env_arrays:
+                    subs[f'{arr_name}[self]'] = f'{arr_name}_{agent_name}'
+                for v in at.agent_variables:
+                    subs[v.name] = f'{v.name}_{agent_name}'
+                for pname, pval in params.items():
+                    if pname not in subs:
+                        if isinstance(pval, str) and not str(pval).lstrip('-').isdigit():
+                            subs[pname] = f"'{pval}'"
+                        else:
+                            subs[pname] = str(pval)
+                cond_text = _substitute(cond_text, subs)
+                read_vars = [
+                    f'{r.indexed_name}_{agent_name}' if r.indexed_name else r.plain_name
+                    for r in ck.read_vars_raw
+                    if r.indexed_name or r.plain_name
+                ]
+                expanded.environment_checks.append(ExpandedCheck(
+                    name=f'{ck.name}_{agent_name}',
+                    condition_text=cond_text,
+                    read_vars=read_vars,
+                ))
+
+    # --- Step 8b: pass through top-level environment_checks ---
+    # These are cross-agent checks that reference specific expanded variable names.
+    # read_variables that name an array variable are expanded to all agent instances.
+    # indexed refs like x_pos[r0] in the condition are resolved to x_pos_r0.
+    for ck in model.environment_checks:
+        cond_text = _cs_to_text(ck.condition)
+        for arr_name in env_arrays:
+            for agent_name in agent_names:
+                cond_text = cond_text.replace(
+                    f'{arr_name}[{agent_name}]', f'{arr_name}_{agent_name}'
+                )
+        for blv in agent_local_vars:
+            for agent_name in agent_names:
+                cond_text = cond_text.replace(
+                    f'{blv}[{agent_name}]', f'{blv}_{agent_name}'
+                )
+        read_vars = []
+        for v in ck.read_variables:
+            if v.name in env_arrays:
+                for agent_name in agent_names:
+                    read_vars.append(f'{v.name}_{agent_name}')
+            else:
+                read_vars.append(v.name)
+        expanded.environment_checks.append(ExpandedCheck(
+            name=ck.name,
+            condition_text=cond_text,
+            read_vars=read_vars,
+        ))
+
+    # --- Step 9: expand actions from agent_type template ---
+    if at:
+        for act in at.agent_actions:
+            for agent_name in agent_names:
+                params = agent_params[agent_name]
+                subs = {}
+                for v in at.agent_variables:
+                    subs[v.name] = f'{v.name}_{agent_name}'
+                for arr_name in env_arrays:
+                    subs[f'{arr_name}[self]'] = f'{arr_name}_{agent_name}'
+                for pname, pval in params.items():
+                    if pname not in subs:
+                        if isinstance(pval, str) and not str(pval).lstrip('-').isdigit():
+                            subs[pname] = f"'{pval}'"
+                        else:
+                            subs[pname] = str(pval)
+                # Build update text from pre_update_statements + return
+                update_parts = []
+                for stmt in act.pre_update_statements:
+                    if stmt.variable_statement:
+                        vs = stmt.variable_statement
+                        assign_text = _substitute(_assign_to_text(vs.assign), subs)
+                        var_nm = _substitute(vs.var_name, subs)
+                        update_parts.append(
+                            f'variable_statement {{{var_nm} {assign_text}}}'
+                        )
+                rs = act.return_statement
+                ret_status = rs.default_result.status if rs and rs.default_result else 'success'
+                update_parts.append(f'return_statement {{result{{{ret_status}}}}}')
+                update_text = '\n            '.join(update_parts)
+                write_vars = [
+                    f'{r.plain_name}_{agent_name}' if r.plain_name else f'{r.indexed_name}_{agent_name}'
+                    for r in act.write_vars_raw
+                ]
+                expanded.action_nodes.append(ExpandedAction(
+                    name=f'{act.name}_{agent_name}',
+                    write_vars=write_vars,
+                    update_text=update_text,
+                ))
+
+    # --- Step 10: build tree ---
+    agent_subtrees = []
+    if at:
+        for agent_name in agent_names:
+            subtree = _expand_agent_tree(
+                at.agent_root, agent_name, at
+            )
+            agent_subtrees.append(subtree)
+
+    root = ExpandedTreeNode(
+        node_type='parallel',
+        name='Root',
+        children=agent_subtrees,
+        parallel_policy='success_on_all',
+    )
+    expanded.tree = root
+
+    # --- Step 11: expand specifications ---
+    expanded.specifications = _expand_specifications(
+        model, agent_names, env_arrays, agent_local_vars, agent_params, consts
+    )
+
+    # --- Metadata ---
+    expanded.configuration_text = _config_to_text(model)
+    expanded.enumerations = list(model.enumerations)
+    expanded.constants_text = _constants_to_text(model)
+    expanded.tick_prerequisite_text = _cs_to_text(model.tick_condition)
+
+    return expanded
+
+
+# ---------------------------------------------------------------------------
+# Tree expansion
+# ---------------------------------------------------------------------------
+
+def _expand_agent_tree(agent_node, agent_name, at):
+    """Recursively expand an agent_node into an ExpandedTreeNode."""
+    # Composite node
+    if hasattr(agent_node, 'children'):
+        node_type = agent_node.node_type
+        parallel_policy = getattr(agent_node, 'parallel_policy', 'success_on_all')
+        children = [_expand_agent_tree(c, agent_name, at) for c in agent_node.children]
+        return ExpandedTreeNode(
+            node_type=node_type,
+            name=f'{agent_node.name}_{agent_name}',
+            children=children,
+            parallel_policy=parallel_policy,
+        )
+    # Leaf node
+    leaf_name = agent_node.leaf_name
+    return ExpandedTreeNode(
+        node_type='leaf',
+        name=f'{leaf_name}_{agent_name}',
+        leaf_name=f'{leaf_name}_{agent_name}',
+    )
+
+
+# ---------------------------------------------------------------------------
+# Environment update expansion
+# ---------------------------------------------------------------------------
+
+def _expand_env_update(model, agent_names, env_arrays, agent_local_vars, consts):
+    """
+    Expand variable_statement { x_pos[i] ... } loops into N concrete statements.
+    Returns the full environment_update body as .tree text.
+    """
+    parts = []
+    for vs in model.update:
+        if vs.indexed_var_name:
+            # This is an indexed statement: x_pos[i] or act[i]
+            base_name = vs.indexed_var_name
+            idx_var = vs.indexed_var_idx  # usually 'i'
+            assign_text = _assign_to_text(vs.assign)
+            for agent_name in agent_names:
+                # Substitute [i] → agent-specific suffix in assign text
+                subs = {}
+                # env arrays: x_pos[i] → x_pos_rN
+                for arr in env_arrays:
+                    subs[f'{arr}[{idx_var}]'] = f'{arr}_{agent_name}'
+                # bl vars: act[i] → act_rN
+                for blv in agent_local_vars:
+                    subs[f'{blv}[{idx_var}]'] = f'{blv}_{agent_name}'
+                flat_name = f'{base_name}_{agent_name}'
+                flat_assign = _substitute(assign_text, subs)
+                parts.append(
+                    f'    variable_statement {{ {flat_name}\n'
+                    f'        {flat_assign}}}'
+                )
+        else:
+            # Regular (non-indexed) statement — pass through with agent-ref substitution.
+            # Resolves arr_name[agent_name] → arr_name_agent_name so that a non-indexed
+            # statement can reference expanded array variables by explicit agent name,
+            # e.g. (or, on_bridge[r0], on_bridge[r1], on_bridge[r2]) → correct flat refs.
+            var_nm = vs.variable.name if vs.variable else 'UNKNOWN'
+            assign_text = _assign_to_text(vs.assign)
+            for arr_name in env_arrays:
+                for agent_name in agent_names:
+                    assign_text = assign_text.replace(
+                        f'{arr_name}[{agent_name}]', f'{arr_name}_{agent_name}'
+                    )
+            for blv in agent_local_vars:
+                for agent_name in agent_names:
+                    assign_text = assign_text.replace(
+                        f'{blv}[{agent_name}]', f'{blv}_{agent_name}'
+                    )
+            parts.append(
+                f'    variable_statement {{ {var_nm}\n'
+                f'        {assign_text}}}'
+            )
+    return '\n'.join(parts)
+
+
+# ---------------------------------------------------------------------------
+# Specification expansion
+# ---------------------------------------------------------------------------
+
+def _expand_specifications(model, agent_names, env_arrays, agent_local_vars,
+                            agent_params, consts):
+    """
+    Expand specifications:
+    - CTLSPEC/LTLSPEC with top-level (forall, i, agents, P(i)) → N separate specs
+    - INVARSPEC with forall → expand inline, simplifying agent-identity comparisons
+    """
+    result = []
+    for spec in model.specifications:
+        body = _cs_to_text(spec.code_statement)
+        spec_type = spec.spec_type
+
+        # Check if the body's outermost call is (forall/exists, var, agents, BODY)
+        outermost = _try_extract_top_forall(body)
+        if outermost and spec_type in ('CTLSPEC', 'LTLSPEC'):
+            # Generate one spec per agent
+            quant, var, domain, inner_body = outermost
+            if domain.strip() == 'agents':
+                for agent_name in agent_names:
+                    expanded = _substitute_agent_in_body(
+                        inner_body, var, agent_name,
+                        env_arrays, agent_local_vars, agent_params, consts
+                    )
+                    # Expand any nested forall/exists
+                    expanded = _expand_spec_body(
+                        expanded, agent_names, env_arrays, agent_local_vars,
+                        agent_params, consts
+                    )
+                    result.append(ExpandedSpec(spec_type, expanded))
+                continue
+
+        # Default: expand inline
+        expanded_body = _expand_spec_body(
+            body, agent_names, env_arrays, agent_local_vars, agent_params, consts
+        )
+        # Simplify agent-identity comparisons (neq/eq of agent names)
+        expanded_body = _simplify_agent_identities(expanded_body, agent_names)
+        result.append(ExpandedSpec(spec_type, expanded_body))
+
+    return result
+
+
+def _try_extract_top_forall(text):
+    """
+    If text is '(forall/exists, var, domain, body)', return (quant, var, domain, body).
+    Otherwise return None.
+    """
+    text = text.strip()
+    if not (text.startswith('(') and text.endswith(')')):
+        return None
+    inner = text[1:-1]
+    parts = _split_top_level(inner)
+    if len(parts) < 4:
+        return None
+    quant = parts[0].strip()
+    if quant not in ('forall', 'exists'):
+        return None
+    var = parts[1].strip()
+    domain = parts[2].strip()
+    body = ', '.join(parts[3:]).strip()
+    return (quant, var, domain, body)
+
+
+def _simplify_agent_identities(text, agent_names):
+    """
+    Replace compile-time agent identity comparisons:
+      (eq, rA, rA) → True    (eq, rA, rB) where A≠B → False
+      (neq, rA, rA) → False  (neq, rA, rB) where A≠B → True
+    Then simplify:
+      (implies, True, X) → X
+      (implies, False, X) → True
+    Filter out True values in (and, ...) conjunctions.
+    """
+    for na in agent_names:
+        for nb in agent_names:
+            same = (na == nb)
+            text = text.replace(f'(eq, {na}, {nb})', 'True' if same else 'False')
+            text = text.replace(f'(neq, {na}, {nb})', 'False' if same else 'True')
+
+    # Simplify (implies, True, X) → X   (simple regex-free approach)
+    # We do multiple passes since nesting requires it
+    for _ in range(5):
+        text = _simplify_implies(text)
+
+    # Simplify (and, ...) by removing True items
+    text = _remove_true_from_and(text)
+
+    return text
+
+
+def _simplify_implies(text):
+    """Replace (implies, True, X) → X and (implies, False, X) → True."""
+    # (implies, True, X)
+    pat = '(implies, True, '
+    while pat in text:
+        idx = text.find(pat)
+        start_of_x = idx + len(pat)
+        # Find the end of X (matching paren for the full implies)
+        full_inner = _extract_inner(text, idx)
+        if full_inner is None:
+            break
+        # Parse (implies, True, X) — X is everything after 'True, '
+        inner_parts = _split_top_level(full_inner)
+        if len(inner_parts) < 3 or inner_parts[0].strip() != 'implies' or inner_parts[1].strip() != 'True':
+            break
+        x = ', '.join(inner_parts[2:]).strip()
+        end_idx = idx + len(full_inner) + 2
+        text = text[:idx] + x + text[end_idx:]
+
+    # (implies, False, X) → True
+    pat = '(implies, False, '
+    while pat in text:
+        idx = text.find(pat)
+        full_inner = _extract_inner(text, idx)
+        if full_inner is None:
+            break
+        inner_parts = _split_top_level(full_inner)
+        if len(inner_parts) < 3 or inner_parts[0].strip() != 'implies' or inner_parts[1].strip() != 'False':
+            break
+        end_idx = idx + len(full_inner) + 2
+        text = text[:idx] + 'True' + text[end_idx:]
+
+    return text
+
+
+def _remove_true_from_and(text):
+    """
+    Simplify (and, True, X) → X, (and, X, True) → X, etc.
+    Works for 2-argument and expressions.
+    """
+    for _ in range(5):
+        changed = False
+        idx = text.find('(and, True, ')
+        if idx != -1:
+            full_inner = _extract_inner(text, idx)
+            if full_inner:
+                parts = _split_top_level(full_inner)
+                if len(parts) >= 2 and parts[0].strip() == 'and' and parts[1].strip() == 'True':
+                    remainder = ', '.join(parts[2:]).strip()
+                    end_idx = idx + len(full_inner) + 2
+                    text = text[:idx] + remainder + text[end_idx:]
+                    changed = True
+        idx2 = text.find('(and, ')
+        while idx2 != -1:
+            full_inner = _extract_inner(text, idx2)
+            if full_inner is None:
+                break
+            parts = _split_top_level(full_inner)
+            if (len(parts) == 3 and parts[0].strip() == 'and' and
+                    parts[2].strip() == 'True'):
+                remainder = parts[1].strip()
+                end_idx = idx2 + len(full_inner) + 2
+                text = text[:idx2] + remainder + text[end_idx:]
+                changed = True
+                break
+            idx2 = text.find('(and, ', idx2 + 1)
+        if not changed:
+            break
+    return text
+
+
+def _expand_spec_body(text, agent_names, env_arrays, agent_local_vars,
+                      agent_params, consts):
+    """
+    Text-level expansion of forall/exists quantifiers and indexed references.
+    Works on the serialized spec text.
+    """
+    # Expand (forall, i, agents, BODY) → (and, BODY[i=r0], BODY[i=r1], ...)
+    # Expand (exists, i, agents, BODY) → (or, BODY[i=r0], BODY[i=r1], ...)
+    changed = True
+    while changed:
+        changed = False
+        for quant, op in (('forall', 'and'), ('exists', 'or')):
+            idx = text.find(f'({quant}, ')
+            if idx == -1:
+                continue
+            inner = _extract_inner(text, idx)
+            if inner is None:
+                continue
+            parts = _split_top_level(inner)
+            if len(parts) < 4:
+                continue
+            q, var, domain, *body_parts = parts
+            q = q.strip()
+            var = var.strip()
+            domain = domain.strip()
+            body = ', '.join(body_parts).strip()
+            if domain != 'agents':
+                continue
+            # Expand body for each agent
+            expanded_parts = []
+            for agent_name in agent_names:
+                b = _substitute_agent_in_body(
+                    body, var, agent_name, env_arrays, agent_local_vars,
+                    agent_params, consts
+                )
+                expanded_parts.append(b)
+            if len(expanded_parts) == 1:
+                replacement = expanded_parts[0]
+            else:
+                inner_joined = ', '.join(expanded_parts)
+                replacement = f'({op}, {inner_joined})'
+            end_idx = idx + len(inner) + 2  # +2 for parens
+            text = text[:idx] + replacement + text[end_idx:]
+            changed = True
+            break
+
+    return text
+
+
+def _extract_inner(text, start):
+    """Extract the content between matching parens starting at start."""
+    if start >= len(text) or text[start] != '(':
+        return None
+    depth = 0
+    for i in range(start, len(text)):
+        if text[i] == '(':
+            depth += 1
+        elif text[i] == ')':
+            depth -= 1
+            if depth == 0:
+                return text[start + 1:i]
+    return None
+
+
+def _split_top_level(text):
+    """Split text by top-level commas (not inside parens/braces)."""
+    parts = []
+    depth = 0
+    current = ''
+    for ch in text:
+        if ch in '({[':
+            depth += 1
+            current += ch
+        elif ch in ')}]':
+            depth -= 1
+            current += ch
+        elif ch == ',' and depth == 0:
+            parts.append(current)
+            current = ''
+        else:
+            current += ch
+    if current:
+        parts.append(current)
+    return parts
+
+
+def _substitute_agent_in_body(body, var, agent_name, env_arrays,
+                               agent_local_vars, agent_params, consts):
+    """
+    Substitute index variable 'var' with agent_name-specific references.
+    e.g. if var='i', replace x_pos[i] → x_pos_rN, goal_x[i] → resolved_val
+    """
+    subs = {}
+    # env arrays: x_pos[i] → x_pos_rN, including 'at' variants
+    for arr in env_arrays:
+        subs[f'{arr}[{var}]'] = f'{arr}_{agent_name}'
+    # goal parameters: goal_x[i] → value for this agent
+    params = agent_params.get(agent_name, {})
+    for pname, pval in params.items():
+        if isinstance(pval, str) and not str(pval).lstrip('-').isdigit():
+            val_str = f"'{pval}'"
+        else:
+            val_str = str(pval)
+        subs[f'{pname}[{var}]'] = val_str
+    # Also substitute the bare index variable in non-indexed contexts
+    # (e.g., (neq, i, j) where i/j are agent IDs as string refs)
+    # We replace the bare 'var' only when it's the exact var name
+    subs[f', {var},'] = f', {agent_name},'
+    subs[f', {var})'] = f', {agent_name})'
+    subs[f'({var},'] = f'({agent_name},'
+    result = _substitute(body, subs)
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Variable helpers
+# ---------------------------------------------------------------------------
+
+def _expand_variable(var):
+    """Convert a TextX variable object to ExpandedVariable."""
+    if var is None:
+        return None
+    domain_text = _domain_to_text(var.domain)
+    init_text = _assign_to_text(var.assign)
+    return ExpandedVariable(
+        name=var.name,
+        scope=var.var_type,
+        domain_text=domain_text,
+        initial_text=init_text,
+    )
+
+
+def _domain_to_text(domain):
+    """Convert a variable_domain AST to string."""
+    if domain is None:
+        return 'INT'
+    if domain.boolean:
+        return 'BOOLEAN'
+    if domain.true_int:
+        return 'INT'
+    if domain.true_real:
+        return 'REAL'
+    if domain.min_val is not None and domain.max_val is not None:
+        return f'[{_cs_to_text(domain.min_val)}, {_cs_to_text(domain.max_val)}]'
+    if domain.domain_codes:
+        inner = ', '.join(f"'{_cs_to_text(c)}'" if not str(_cs_to_text(c)).startswith("'") else _cs_to_text(c)
+                          for c in domain.domain_codes)
+        return '{' + inner + '}'
+    return 'INT'
+
+
+def _extract_agent_param_from_assign(assign_val):
+    """
+    Extract the parameter name from an assign like assign{result{agents[i].param_name}}.
+    Returns param_name string or None.
+    """
+    if assign_val is None:
+        return None
+    dr = assign_val.default_result
+    if dr and dr.values:
+        cs = dr.values[0]
+        if cs.agent_param_ref:
+            return cs.agent_param_name
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Model metadata helpers
+# ---------------------------------------------------------------------------
+
+def _config_to_text(model):
+    parts = []
+    if model.hypersafety:
+        parts.append('hypersafety')
+    if model.use_reals:
+        parts.append('use_reals')
+    if model.neural:
+        parts.append('neural')
+    return ' '.join(parts)
+
+
+def _constants_to_text(model):
+    parts = []
+    for c in model.constants:
+        val = c.val
+        if hasattr(val, 'val') and val.val is not None:
+            parts.append(f'{c.name} := {val.val}')
+        else:
+            parts.append(f'{c.name} := {val}')
+    return ', '.join(parts)
+
+
+# ---------------------------------------------------------------------------
+# Passthrough for non-multi-agent models
+# ---------------------------------------------------------------------------
+
+def _passthrough(model):
+    """Wrap a regular (non-multi-agent) model as ExpandedModel (minimal)."""
+    expanded = ExpandedModel()
+    for var in model.variables:
+        ev = _expand_variable(var)
+        if ev:
+            expanded.variables.append(ev)
+    expanded.configuration_text = _config_to_text(model)
+    expanded.enumerations = list(model.enumerations)
+    expanded.constants_text = _constants_to_text(model)
+    expanded.tick_prerequisite_text = _cs_to_text(model.tick_condition)
+    for spec in model.specifications:
+        expanded.specifications.append(ExpandedSpec(
+            spec.spec_type, _cs_to_text(spec.code_statement)
+        ))
+    return expanded
+
+
+# ---------------------------------------------------------------------------
+# Serialization: model_to_tree_text
+# ---------------------------------------------------------------------------
+
+def model_to_tree_text(expanded):
+    """
+    Serialize an ExpandedModel to valid standard .tree text.
+
+    Args:
+        expanded: ExpandedModel
+
+    Returns:
+        str containing a complete .tree file that the existing pipeline accepts.
+    """
+    lines = []
+
+    # configuration
+    lines.append(f'configuration {{{expanded.configuration_text}}}')
+
+    # enumerations
+    enum_inner = ', '.join(f"'{e}'" for e in expanded.enumerations)
+    lines.append(f'enumerations {{{enum_inner}}}')
+
+    # constants
+    lines.append(f'constants {{{expanded.constants_text}}}')
+
+    # variables
+    lines.append('variables {')
+    for v in expanded.variables:
+        lines.append(f'    {v.to_tree_text()}')
+    lines.append('}')
+
+    # environment_update
+    lines.append('environment_update {')
+    if expanded.environment_update_text:
+        lines.append(expanded.environment_update_text)
+    lines.append('}')
+
+    # checks
+    lines.append('checks {}')
+
+    # environment_checks
+    lines.append('environment_checks {')
+    for ck in expanded.environment_checks:
+        lines.append(f'    {ck.to_tree_text()}')
+    lines.append('}')
+
+    # actions
+    lines.append('actions {')
+    for act in expanded.action_nodes:
+        lines.append(f'    {act.to_tree_text()}')
+    lines.append('}')
+
+    # sub_trees
+    lines.append('sub_trees {}')
+
+    # tree
+    lines.append('tree {')
+    if expanded.tree:
+        lines.append(expanded.tree.to_tree_text(indent=4))
+    lines.append('}')
+
+    # tick_prerequisite
+    lines.append(f'tick_prerequisite {{{expanded.tick_prerequisite_text}}}')
+
+    # specifications
+    lines.append('specifications {')
+    for spec in expanded.specifications:
+        lines.append(f'    {spec}')
+    lines.append('}')
+
+    return '\n'.join(lines) + '\n'
+
+
+# ---------------------------------------------------------------------------
+# Public entry point for behaverify.py
+# ---------------------------------------------------------------------------
+
+def maybe_expand(model_file_path):
+    """
+    Detect whether a .tree file uses multi-agent syntax.
+    If yes, expand it and write the result to a temp file, returning the temp path.
+    If no, return the original path unchanged.
+
+    Args:
+        model_file_path: str path to a .tree file
+
+    Returns:
+        str path — either the original or a temp expanded file
+    """
+    try:
+        with open(model_file_path, 'r', encoding='utf-8') as f:
+            content = f.read()
+    except OSError:
+        return model_file_path
+
+    if 'agent_types' not in content and 'agents' not in content:
+        return model_file_path
+
+    try:
+        from textx import metamodel_from_file
+        try:
+            from importlib.resources import files
+            tx_file = str(files('behaverify').joinpath('data', 'metamodel', 'behaverify.tx'))
+        except Exception:
+            tx_file = os.path.join(
+                os.path.dirname(os.path.realpath(__file__)),
+                'data', 'metamodel', 'behaverify.tx'
+            )
+        mm = metamodel_from_file(tx_file)
+        model = mm.model_from_file(model_file_path)
+        expanded = expand_agents(model)
+        tree_text = model_to_tree_text(expanded)
+
+        # Write to a temp file
+        suffix = Path(model_file_path).stem + '_expanded.tree'
+        tmp = tempfile.NamedTemporaryFile(
+            mode='w', suffix='.tree', prefix='behaverify_',
+            delete=False, encoding='utf-8'
+        )
+        tmp.write(tree_text)
+        tmp.close()
+        return tmp.name
+    except Exception as e:
+        print(f'[agent_expander] Warning: expansion failed ({e}), using original file.')
+        return model_file_path

--- a/src/behaverify/behaverify.py
+++ b/src/behaverify/behaverify.py
@@ -23,6 +23,11 @@ from behaverify.counter_trace import counter_trace
 from behaverify.grid_world_draw.parse_nuxmv_output import handle_file as grid_world_draw_nuxmv_output
 from behaverify.grid_world_draw.parse_python_output import handle_file as grid_world_draw_python_output
 from behaverify.behaverify_gui import main as gui_main
+try:
+    from behaverify.agent_expander import maybe_expand as _maybe_expand_multiagent
+except ImportError:
+    def _maybe_expand_multiagent(path):
+        return path
 
 __version__ = '1.0.0'
 
@@ -535,6 +540,7 @@ For detailed documentation: https://github.com/verivital/behaverify
             help='Overwrite existing output files/directories')
         args = arg_parser.parse_args(argv)
         verify_input(args.model_file)
+        args.model_file = _maybe_expand_multiagent(args.model_file)
         verify_location('cpp', args.location, args.overwrite)
         output_name = args.output_name if args.output_name is not None else os.path.splitext(os.path.basename(args.model_file))[0]
         dsl_to_cpp(metamodel_file, args.model_file, output_name, os.path.join(args.location, 'cpp'), args.serene_print, args.max_iter, args.no_var_print, args.py_tree_print, args.recursion_limit, args.safe_assignment, args.no_checks)
@@ -630,6 +636,7 @@ For detailed documentation: https://github.com/verivital/behaverify
             help='Overwrite existing output files/directories')
         args = arg_parser.parse_args(argv)
         verify_input(args.model_file)
+        args.model_file = _maybe_expand_multiagent(args.model_file)
         verify_location('haskell', args.location, args.overwrite)
         output_name = args.output_name if args.output_name is not None else os.path.splitext(os.path.basename(args.model_file))[0]
         dsl_to_haskell(metamodel_file, args.model_file, os.path.join(args.location, 'haskell'), output_name, args.max_iter, args.recursion_limit, args.no_checks)
@@ -712,6 +719,7 @@ Examples:
             help='Print verification results summary to console')
         args = arg_parser.parse_args(argv)
         verify_input(args.model_file)
+        args.model_file = _maybe_expand_multiagent(args.model_file)
         verify_location('nuxmv', args.location, args.overwrite)
         input_file = args.model_file
         # output_file = set_output(args.location, input_file, args.output_name, extra_directory = 'nuxmv', extension = ('.smv' if args.generate else '.txt'))
@@ -771,6 +779,7 @@ Examples:
             help='Overwrite existing output files/directories')
         args = arg_parser.parse_args(argv)
         verify_input(args.model_file)
+        args.model_file = _maybe_expand_multiagent(args.model_file)
         verify_location('python', args.location, args.overwrite)
         output_name = args.output_name if args.output_name is not None else os.path.splitext(os.path.basename(args.model_file))[0]
         dsl_to_python(metamodel_file, args.model_file, output_name, os.path.join(args.location, 'python'), args.serene_print, args.max_iter, args.no_var_print, args.py_tree_print, args.recursion_limit, args.safe_assignment, args.no_checks)

--- a/src/behaverify/data/metamodel/behaverify.tx
+++ b/src/behaverify/data/metamodel/behaverify.tx
@@ -36,7 +36,13 @@ BehaviorModel:
     'sub_trees' '{'
     sub_trees *= sub_tree
     '}' ('end_sub_trees')?
-    'tree' '{' root = node '}' ('end_tree')?
+    ('agent_types' '{'
+    agent_types *= agent_type_def
+    '}' ('end_agent_types')?)?
+    ('agents' '{'
+    agents *= agent_instance
+    '}' ('end_agents')?)?
+    ('tree' '{' root = node '}' ('end_tree')?)?
     'tick_prerequisite' '{'
     tick_condition = code_statement
     '}' ('end_tick_prerequisite')?
@@ -188,6 +194,8 @@ node:
           ('default' '{' default_value = assign_value '}' ('end_default')?
           ((constant_index = 'constant_index' assigns *= loop_array_index) | (constant_index = '' assigns *= loop_array_index)))))
           |
+          ('[' agents_array = 'agents' ']' (assign = assign_value))
+          |
           (assign = assign_value)
         )
       )
@@ -270,7 +278,7 @@ statement:
     variable_statement:
     'variable_statement' '{'
     instant ?= 'instant'
-    variable = [variable]
+    ((indexed_var_name = ID '[' indexed_var_idx = ID ']') | (variable = [variable]))
     (((constant_index = 'constant_index' assigns += loop_array_index) | (constant_index = '' assigns += loop_array_index))
     | ((iterative_assign = 'iterative_assign' ',' index_var_name = ID iterative_assign_conditionals *= iterative_assign_conditional)? assign = assign_value))
     '}' ('end_variable_statement')?
@@ -334,6 +342,8 @@ statement:
     code_statement:
     ('(' function_call = function ')') |
     ('(' code_statement = code_statement ')') |
+    (agent_param_ref = 'agents' '[' agent_param_index = ID ']' '.' agent_param_name = ID) |
+    (indexed_var = ID '[' indexed_var_index = ID ']' ('at' read_at_idx = code_statement)?) |
     (atom = constant_or_reference ('node' node_name = code_statement)? ('at' read_at = code_statement)? ('trace' trace_num = code_statement)?)
 ;
     //--------------------SEC:FUNCTION_BL_LOCALS--------------------------------  
@@ -350,14 +360,16 @@ statement:
 ;
     //if is 3 args, COND, TRUE, FALSE
     function_names://these need to be ordered so that something like eq is AFTER equiv, otherwise equiv will match eq and cause problems.
-    //start of ctl specific
+    //start of ctl specific (exists_* must come before 'exists' agent quantifier)
     'exists_globally' | 'exists_next' | 'exists_finally' | 'exists_until' | 'always_globally' | 'always_next' | 'always_finally' | 'always_until' |
     //start of ltl specific
-    'next' | 'globally' | 'finally' | 'until' | 'release' | 'previous' | 'not_previous_not' | 'historically' | 'once' | 'since' | 'triggered' | 
+    'next' | 'globally' | 'finally' | 'until' | 'release' | 'previous' | 'not_previous_not' | 'historically' | 'once' | 'since' | 'triggered' |
     //these functions permit the continuation of ltl/ctl specific functions
     'not' | 'and' | 'or' | 'xor' | 'xnor' | 'implies' | 'equivalent' |
     //the rest.
-    'if' | 'abs' | 'max' | 'min' | 'sin' | 'cos' | 'exp' | 'tan' | 'ln' | 'eq' | 'neq' | 'lte' | 'gte' | 'lt' | 'gt' | 'neg' | 'add' | 'sub' | 'mult' | 'idiv' | 'mod' | 'rdiv' | 'floor' | 'count'
+    'if' | 'abs' | 'max' | 'min' | 'sin' | 'cos' | 'exp' | 'tan' | 'ln' | 'eq' | 'neq' | 'lte' | 'gte' | 'lt' | 'gt' | 'neg' | 'add' | 'sub' | 'mult' | 'idiv' | 'mod' | 'rdiv' | 'floor' | 'count' |
+    //agent quantifiers (after exists_* to avoid prefix ambiguity)
+    'forall' | 'exists'
 ;
     bounded_function_names:
     'globally_bounded' | 'finally_bounded' | 'until_bounded' | 'release_bounded' | 'historically_bounded' | 'once_bounded' | 'since_bounded' | 'triggered_bounded'
@@ -370,4 +382,111 @@ specification:
     (spec_type = 'LTLSPEC' '{' code_statement = code_statement '}' ('end_LTLSPEC')?) |
     (spec_type = 'CTLSPEC' '{' code_statement = code_statement '}' ('end_CTLSPEC')?) |
     (spec_type = 'INVARSPEC' '{' code_statement = code_statement '}' ('end_INVARSPEC')?)
+;
+    //--------------------SEC:AGENT_TYPES--------------------------
+    // agent_var_ref: flexible variable reference used in agent_type templates
+    // (allows indexed refs like x_pos[self] that cannot be cross-refs)
+    agent_var_ref:
+    (indexed_name = ID '[' index = ID ']') | (plain_name = ID)
+;
+    // agent_parameter_def: one parameter declaration inside agent_type
+    agent_parameter_def:
+    name = ID ':' domain = variable_domain
+;
+    // agent_variable_statement: like variable_statement but variable by plain name (no cross-ref)
+    agent_variable_statement:
+    'variable_statement' '{'
+    instant ?= 'instant'
+    var_name = ID
+    (assign = assign_value)
+    '}' ('end_variable_statement')?
+;
+    // agent_statement: statement variant for agent_type action update bodies
+    agent_statement:
+    (variable_statement = agent_variable_statement)
+;
+    // agent_template_check: environment_check inside agent_type
+    // Uses agent_var_ref for read_variables (no cross-refs needed)
+    agent_template_check:
+    'environment_check' '{'
+    name = ID
+    'arguments' '{' arguments *= argument_declaration[','] '}' ('end_arguments')?
+    'read_variables' '{' read_vars_raw *= agent_var_ref[','] '}' ('end_read_variables')?
+    'condition' '{' condition = code_statement '}' ('end_condition')?
+    '}' ('end_environment_check')?
+;
+    // agent_template_action: action inside agent_type
+    agent_template_action:
+    'action' '{'
+    name = ID
+    'arguments' '{' arguments *= argument_declaration[','] '}' ('end_arguments')?
+    'local_variables' '{' local_vars_raw *= agent_var_ref[','] '}' ('end_local_variables')?
+    'read_variables' '{' read_vars_raw *= agent_var_ref[','] '}' ('end_read_variables')?
+    'write_variables' '{' write_vars_raw *= agent_var_ref[','] '}' ('end_write_variables')?
+    'initial_values' '{'
+    init_statements *= agent_variable_statement
+    '}' ('end_initial_values')?
+    'update' '{'
+    pre_update_statements *= agent_statement
+    return_statement = return_statement
+    post_update_statements *= agent_statement
+    '}' ('end_update')?
+    '}' ('end_action')?
+;
+    // agent_leaf_node: leaf node inside agent_type tree (no cross-refs)
+    agent_leaf_node:
+    (node_name = ID ':')?
+    leaf_name = ID
+    '{'
+    arguments *= code_statement[',']
+    '}'
+;
+    // agent_composite_node: composite node inside agent_type tree
+    agent_composite_node:
+    'composite' '{'
+    name = ID
+    ((node_type = 'parallel' 'policy'
+    (parallel_policy = 'success_on_all' | parallel_policy = 'success_on_one'))
+    |
+    (node_type = 'sequence') | (node_type = 'selector'))
+    (memory = 'with_partial_memory' | memory = 'with_true_memory' | memory = '')
+    'children' '{'
+    children += agent_node
+    '}' ('end_children')?
+    '}' ('end_composite')?
+;
+    // agent_node: node variant for inside agent_type tree
+    agent_node:
+    agent_composite_node | agent_leaf_node
+;
+    // agent_type_def: full agent_type block with parameters + template
+    agent_type_def:
+    'agent_type' '{'
+    name = ID
+    'parameters' '{'
+    parameters *= agent_parameter_def
+    '}' ('end_parameters')?
+    ('variables' '{'
+    agent_variables *= variable
+    '}' ('end_variables')?)?
+    ('environment_checks' '{'
+    agent_environment_checks *= agent_template_check
+    '}' ('end_environment_checks')?)?
+    ('actions' '{'
+    agent_actions *= agent_template_action
+    '}' ('end_actions')?)?
+    'tree' '{' agent_root = agent_node '}' ('end_tree')?
+    '}' ('end_agent_type')?
+;
+    // agent_param_assignment: parameter value supplied in agent { } block
+    agent_param_assignment:
+    name = ID ':=' value = constant_or_reference
+;
+    // agent_instance: one agent instantiation in the agents { } block
+    agent_instance:
+    'agent' '{'
+    name = ID
+    type_name = ID
+    param_assignments *= agent_param_assignment[',']
+    '}'
 ;

--- a/test_examples/multi_agent/2DLivelock_multiagent.tree
+++ b/test_examples/multi_agent/2DLivelock_multiagent.tree
@@ -1,0 +1,117 @@
+configuration {}
+enumerations {'We', 'Ea', 'No', 'So', 'XX'}
+constants {min_x := 0, max_x := 3, min_y := 0, max_y := 1}
+
+variables {
+    variable { env x_pos VAR [min_x, max_x] [agents] assign{result{agents[i].start_x}}}
+    variable { env y_pos VAR [min_y, max_y] [agents] assign{result{agents[i].start_y}}}
+}
+
+environment_update {
+    variable_statement { x_pos[i]
+        assign {
+            case {(eq, act[i], 'Ea')} result {(min, max_x, (add, x_pos[i], 1))}
+            case {(eq, act[i], 'We')} result {(max, min_x, (sub, x_pos[i], 1))}
+            result {x_pos[i]}
+        }
+    }
+    variable_statement { y_pos[i]
+        assign {
+            case {(eq, act[i], 'No')} result {(min, max_y, (add, y_pos[i], 1))}
+            case {(eq, act[i], 'So')} result {(max, min_y, (sub, y_pos[i], 1))}
+            result {y_pos[i]}
+        }
+    }
+}
+
+checks {}
+
+#{ PathClear checks reference both robots and cannot be templated.
+   The condition uses x_pos[r0]/x_pos[r1] indexed syntax, which the
+   expander resolves to x_pos_r0/x_pos_r1 in the flat output.
+   read_variables lists the array base names; the expander expands
+   them to all per-agent instances. }#
+environment_checks {
+    environment_check { PathClear_r0
+        arguments {} read_variables {x_pos, y_pos}
+        condition {(not, (and, (eq, x_pos[r1], (add, x_pos[r0], 1)), (eq, y_pos[r1], y_pos[r0])))}}
+    environment_check { PathClear_r1
+        arguments {} read_variables {x_pos, y_pos}
+        condition {(not, (and, (eq, x_pos[r0], (sub, x_pos[r1], 1)), (eq, y_pos[r0], y_pos[r1])))}}
+}
+
+actions {}
+sub_trees {}
+
+agent_types {
+    agent_type { Robot
+        parameters {
+            start_x : [min_x, max_x]
+            start_y : [min_y, max_y]
+            goal_x  : [min_x, max_x]
+            goal_y  : [min_y, max_y]
+            forward_dir : {'We', 'Ea', 'No', 'So', 'XX'}
+        }
+        variables {
+            variable { bl act VAR {'We', 'Ea', 'No', 'So', 'XX'} assign{result{'XX'}}}
+        }
+        environment_checks {
+            environment_check { AtGoal
+                arguments {} read_variables {x_pos[self], y_pos[self]}
+                condition {(and, (eq, x_pos[self], goal_x), (eq, y_pos[self], goal_y))}}
+            environment_check { OnUpperRow
+                arguments {} read_variables {y_pos[self]}
+                condition {(gt, y_pos[self], min_y)}}
+        }
+        actions {
+            action { MoveForward
+                arguments {} local_variables {} read_variables {} write_variables {act}
+                initial_values {}
+                update {
+                    variable_statement {act assign{result{forward_dir}}}
+                    return_statement {result{success}}
+                }
+            }
+            action { StepSouth
+                arguments {} local_variables {} read_variables {} write_variables {act}
+                initial_values {}
+                update {
+                    variable_statement {act assign{result{'So'}}}
+                    return_statement {result{success}}
+                }
+            }
+            action { StepNorth
+                arguments {} local_variables {} read_variables {} write_variables {act}
+                initial_values {}
+                update {
+                    variable_statement {act assign{result{'No'}}}
+                    return_statement {result{success}}
+                }
+            }
+        }
+        tree {
+            composite { RobotRoot selector children {
+                AtGoal {}
+                composite { TryForward sequence children { PathClear {} MoveForward {} }}
+                composite { Sidestep selector children {
+                    composite { SidestepSouth sequence children { OnUpperRow {} StepSouth {} }}
+                    StepNorth {}
+                }}
+            }}
+        }
+    }
+}
+
+agents {
+    agent { r0 Robot start_x := 1, start_y := max_y, goal_x := max_x, goal_y := max_y, forward_dir := 'Ea' }
+    agent { r1 Robot start_x := 2, start_y := max_y, goal_x := min_x, goal_y := max_y, forward_dir := 'We' }
+}
+
+tick_prerequisite {(True)}
+
+specifications {
+    #{  AG AF (robot reaches its goal) - expected FALSE due to livelock }#
+    CTLSPEC {(forall, i, agents, (always_globally, (always_finally, (and, (eq, x_pos[i] at -1, goal_x[i]), (eq, y_pos[i] at -1, goal_y[i])))))}
+    #{  AG EF (robot can reach its goal) - expected TRUE (goal is reachable on some path) }#
+    CTLSPEC {(always_globally, (exists_finally, (and, (eq, x_pos_r0 at -1, max_x), (eq, y_pos_r0 at -1, max_y))))}
+}

--- a/test_examples/multi_agent/FiveInRing_multiagent.tree
+++ b/test_examples/multi_agent/FiveInRing_multiagent.tree
@@ -1,0 +1,146 @@
+configuration {}
+enumerations {'Move', 'Stay'}
+constants {num_pos := 6}
+
+variables {
+    variable { env x_pos VAR [0, 5] [agents] assign{result{agents[i].start_pos}}}
+}
+
+environment_update {
+    variable_statement { x_pos[i]
+        assign {
+            case {(eq, act[i], 'Move')} result {(mod, (add, x_pos[i], 1), num_pos)}
+            result {x_pos[i]}
+        }
+    }
+}
+
+checks {}
+
+#{  PathClear checks reference other agents' positions and cannot be templated.
+    Each robot checks all four other robots' positions against its next clockwise
+    slot. or is variadic so all four comparisons fit in one (or, ...).
+    The expander resolves x_pos[r0] -> x_pos_r0 etc. via step 8b substitution.
+    The tree template references PathClear {} which expands to PathClear_rN per agent. }#
+environment_checks {
+    environment_check { PathClear_r0
+        arguments {} read_variables {x_pos}
+        condition {(not, (or,
+            (eq, x_pos[r1], (mod, (add, x_pos[r0], 1), num_pos)),
+            (eq, x_pos[r2], (mod, (add, x_pos[r0], 1), num_pos)),
+            (eq, x_pos[r3], (mod, (add, x_pos[r0], 1), num_pos)),
+            (eq, x_pos[r4], (mod, (add, x_pos[r0], 1), num_pos))))}}
+    environment_check { PathClear_r1
+        arguments {} read_variables {x_pos}
+        condition {(not, (or,
+            (eq, x_pos[r0], (mod, (add, x_pos[r1], 1), num_pos)),
+            (eq, x_pos[r2], (mod, (add, x_pos[r1], 1), num_pos)),
+            (eq, x_pos[r3], (mod, (add, x_pos[r1], 1), num_pos)),
+            (eq, x_pos[r4], (mod, (add, x_pos[r1], 1), num_pos))))}}
+    environment_check { PathClear_r2
+        arguments {} read_variables {x_pos}
+        condition {(not, (or,
+            (eq, x_pos[r0], (mod, (add, x_pos[r2], 1), num_pos)),
+            (eq, x_pos[r1], (mod, (add, x_pos[r2], 1), num_pos)),
+            (eq, x_pos[r3], (mod, (add, x_pos[r2], 1), num_pos)),
+            (eq, x_pos[r4], (mod, (add, x_pos[r2], 1), num_pos))))}}
+    environment_check { PathClear_r3
+        arguments {} read_variables {x_pos}
+        condition {(not, (or,
+            (eq, x_pos[r0], (mod, (add, x_pos[r3], 1), num_pos)),
+            (eq, x_pos[r1], (mod, (add, x_pos[r3], 1), num_pos)),
+            (eq, x_pos[r2], (mod, (add, x_pos[r3], 1), num_pos)),
+            (eq, x_pos[r4], (mod, (add, x_pos[r3], 1), num_pos))))}}
+    environment_check { PathClear_r4
+        arguments {} read_variables {x_pos}
+        condition {(not, (or,
+            (eq, x_pos[r0], (mod, (add, x_pos[r4], 1), num_pos)),
+            (eq, x_pos[r1], (mod, (add, x_pos[r4], 1), num_pos)),
+            (eq, x_pos[r2], (mod, (add, x_pos[r4], 1), num_pos)),
+            (eq, x_pos[r3], (mod, (add, x_pos[r4], 1), num_pos))))}}
+}
+
+actions {}
+sub_trees {}
+
+agent_types {
+    agent_type { Robot
+        parameters {
+            start_pos : [0, 5]
+            goal_pos  : [0, 5]
+        }
+        variables {
+            variable { bl act VAR {'Move', 'Stay'} assign{result{'Stay'}}}
+        }
+        environment_checks {
+            environment_check { AtGoal
+                arguments {} read_variables {x_pos[self]}
+                condition {(eq, x_pos[self], goal_pos)}}
+        }
+        actions {
+            action { Move
+                arguments {} local_variables {} read_variables {} write_variables {act}
+                initial_values {}
+                update {
+                    variable_statement {act assign{result{'Move'}}}
+                    return_statement {result{success}}
+                }
+            }
+            action { SetStayGoal
+                arguments {} local_variables {} read_variables {} write_variables {act}
+                initial_values {}
+                update {
+                    variable_statement {act assign{result{'Stay'}}}
+                    return_statement {result{success}}
+                }
+            }
+            action { SetStayWait
+                arguments {} local_variables {} read_variables {} write_variables {act}
+                initial_values {}
+                update {
+                    variable_statement {act assign{result{'Stay'}}}
+                    return_statement {result{success}}
+                }
+            }
+        }
+        tree {
+            composite { RobotRoot selector children {
+                composite { AtGoalSeq sequence children {
+                    AtGoal {}
+                    SetStayGoal {}
+                }}
+                composite { TryMove sequence children {
+                    PathClear {}
+                    Move {}
+                }}
+                SetStayWait {}
+            }}
+        }
+    }
+}
+
+agents {
+    agent { r0 Robot start_pos := 0, goal_pos := 3 }
+    agent { r1 Robot start_pos := 1, goal_pos := 4 }
+    agent { r2 Robot start_pos := 2, goal_pos := 5 }
+    agent { r3 Robot start_pos := 3, goal_pos := 0 }
+    agent { r4 Robot start_pos := 4, goal_pos := 5 }
+}
+
+tick_prerequisite {(True)}
+
+specifications {
+    #{  Safety: no two robots occupy the same position }#
+    INVARSPEC {(forall, i, agents, (forall, j, agents,
+        (implies, (neq, i, j), (neq, x_pos[i] at -1, x_pos[j] at -1))))}
+
+    #{  AG AF: every robot always eventually reaches its goal
+        Expected FALSE — r0-r3 are permanently deadlocked after tick 5 }#
+    CTLSPEC {(forall, i, agents, (always_globally, (always_finally,
+        (eq, x_pos[i] at -1, goal_pos[i]))))}
+
+    #{  AG EF: from every state each robot can eventually reach its goal
+        Expected FALSE — from the deadlocked state no path exists for r0-r3 }#
+    CTLSPEC {(forall, i, agents, (always_globally, (exists_finally,
+        (eq, x_pos[i] at -1, goal_pos[i]))))}
+}

--- a/test_examples/multi_agent/ThreeInRing_multiagent.tree
+++ b/test_examples/multi_agent/ThreeInRing_multiagent.tree
@@ -1,0 +1,130 @@
+configuration {}
+enumerations {'Move', 'Stay'}
+constants {num_pos := 4}
+
+variables {
+    variable { env x_pos VAR [0, 3] [agents] assign{result{agents[i].start_pos}}}
+}
+
+environment_update {
+    variable_statement { x_pos[i]
+        assign {
+            case {(eq, act[i], 'Move')} result {(mod, (add, x_pos[i], 1), num_pos)}
+            result {x_pos[i]}
+        }
+    }
+}
+
+checks {}
+
+#{  PathClear checks reference other agents' positions and cannot be templated.
+    Each robot's PathClear checks both other robots' positions against the
+    next clockwise slot. The expander resolves x_pos[r0] -> x_pos_r0 etc.
+    via step 8b substitution. The tree template references PathClear {} which
+    expands to PathClear_r0 / PathClear_r1 / PathClear_r2 per agent. }#
+environment_checks {
+    environment_check { PathClear_r0
+        arguments {} read_variables {x_pos}
+        condition {(not, (or,
+            (eq, x_pos[r1], (mod, (add, x_pos[r0], 1), num_pos)),
+            (eq, x_pos[r2], (mod, (add, x_pos[r0], 1), num_pos))))}}
+    environment_check { PathClear_r1
+        arguments {} read_variables {x_pos}
+        condition {(not, (or,
+            (eq, x_pos[r0], (mod, (add, x_pos[r1], 1), num_pos)),
+            (eq, x_pos[r2], (mod, (add, x_pos[r1], 1), num_pos))))}}
+    environment_check { PathClear_r2
+        arguments {} read_variables {x_pos}
+        condition {(not, (or,
+            (eq, x_pos[r0], (mod, (add, x_pos[r2], 1), num_pos)),
+            (eq, x_pos[r1], (mod, (add, x_pos[r2], 1), num_pos))))}}
+}
+
+actions {}
+sub_trees {}
+
+agent_types {
+    agent_type { Robot
+        parameters {
+            start_pos : [0, 3]
+            goal_pos  : [0, 3]
+        }
+        variables {
+            variable { bl act VAR {'Move', 'Stay'} assign{result{'Stay'}}}
+        }
+        environment_checks {
+            environment_check { AtGoal
+                arguments {} read_variables {x_pos[self]}
+                condition {(eq, x_pos[self], goal_pos)}}
+        }
+        actions {
+            action { Move
+                arguments {} local_variables {} read_variables {} write_variables {act}
+                initial_values {}
+                update {
+                    variable_statement {act assign{result{'Move'}}}
+                    return_statement {result{success}}
+                }
+            }
+            #{  SetStayGoal: resets act when robot reaches its goal, so the
+                environment_update does not advance it past the goal on the
+                next tick (mod arithmetic has no clamping). }#
+            action { SetStayGoal
+                arguments {} local_variables {} read_variables {} write_variables {act}
+                initial_values {}
+                update {
+                    variable_statement {act assign{result{'Stay'}}}
+                    return_statement {result{success}}
+                }
+            }
+            #{  SetStayWait: fallback when PathClear fails. Clears a stale
+                Move from a prior tick so the environment_update does not
+                advance a blocked robot. }#
+            action { SetStayWait
+                arguments {} local_variables {} read_variables {} write_variables {act}
+                initial_values {}
+                update {
+                    variable_statement {act assign{result{'Stay'}}}
+                    return_statement {result{success}}
+                }
+            }
+        }
+        tree {
+            composite { RobotRoot selector children {
+                composite { AtGoalSeq sequence children {
+                    AtGoal {}
+                    SetStayGoal {}
+                }}
+                composite { TryMove sequence children {
+                    PathClear {}
+                    Move {}
+                }}
+                SetStayWait {}
+            }}
+        }
+    }
+}
+
+agents {
+    agent { r0 Robot start_pos := 0, goal_pos := 2 }
+    agent { r1 Robot start_pos := 1, goal_pos := 0 }
+    agent { r2 Robot start_pos := 2, goal_pos := 3 }
+}
+
+tick_prerequisite {(True)}
+
+specifications {
+    #{  Safety: no two robots occupy the same position }#
+    INVARSPEC {(forall, i, agents, (forall, j, agents,
+        (implies, (neq, i, j), (neq, x_pos[i] at -1, x_pos[j] at -1))))}
+
+    #{  AG AF: every robot always eventually reaches its goal
+        Expected FALSE — r0 and r1 are permanently blocked after r2 parks }#
+    CTLSPEC {(forall, i, agents, (always_globally, (always_finally,
+        (eq, x_pos[i] at -1, goal_pos[i]))))}
+
+    #{  AG EF: from every state each robot can eventually reach its goal
+        Expected FALSE — from the deadlocked state no path exists for r0/r1 }#
+    CTLSPEC {(forall, i, agents, (always_globally, (exists_finally,
+        (eq, x_pos[i] at -1, goal_pos[i]))))}
+}

--- a/test_examples/multi_agent/TwoRobot1D_multiagent.tree
+++ b/test_examples/multi_agent/TwoRobot1D_multiagent.tree
@@ -1,0 +1,74 @@
+configuration {}
+enumerations {'We', 'Ea', 'XX'}
+constants {min_val := 0, max_val := 4}
+
+variables {
+    variable { env x_pos VAR [min_val, max_val] [agents]
+        assign { result { agents[i].start_x } }}
+}
+
+environment_update {
+    variable_statement { x_pos[i]
+        assign {
+            case {(eq, act[i], 'We')} result {(max, min_val, (sub, x_pos[i], 1))}
+            case {(eq, act[i], 'Ea')} result {(min, max_val, (add, x_pos[i], 1))}
+            result {x_pos[i]}
+        }
+    }
+}
+
+checks {}
+
+environment_checks {}
+
+actions {}
+
+sub_trees {}
+
+agent_types {
+    agent_type { Robot
+        parameters {
+            start_x : [min_val, max_val]
+            goal_x  : [min_val, max_val]
+        }
+        variables {
+            variable { bl act VAR {'We', 'Ea', 'XX'} assign{result{'XX'}}}
+        }
+        environment_checks {
+            environment_check { AtGoal
+                arguments {} read_variables {x_pos[self]}
+                condition {(eq, x_pos[self], goal_x)}
+            }
+        }
+        actions {
+            action { Move
+                arguments {} local_variables {} read_variables {} write_variables {act}
+                initial_values {}
+                update {
+                    variable_statement {act assign{result{'We', 'Ea'}}}
+                    return_statement {result{success}}
+                }
+            }
+        }
+        tree {
+            composite { RobotRoot selector children {
+                AtGoal {}
+                Move {}
+            }}
+        }
+    }
+}
+
+agents {
+    agent { r0 Robot start_x := min_val, goal_x := max_val }
+    agent { r1 Robot start_x := max_val, goal_x := min_val }
+}
+
+tick_prerequisite {(True)}
+
+specifications {
+    INVARSPEC {(forall, i, agents, (forall, j, agents,
+        (implies, (neq, i, j), (neq, x_pos[i] at -1, x_pos[j] at -1))))}
+    CTLSPEC {(forall, i, agents, (always_globally, (exists_finally,
+        (eq, x_pos[i] at -1, goal_x[i]))))}
+}

--- a/tests/multi_agent/conftest.py
+++ b/tests/multi_agent/conftest.py
@@ -1,0 +1,211 @@
+"""
+Shared fixtures, helpers, and mock AST builders for multi-agent tests.
+
+Imported automatically by pytest for all files in this package.
+"""
+
+import sys
+import pytest
+from pathlib import Path
+from types import SimpleNamespace
+
+REPO_ROOT = Path(__file__).parent.parent.parent
+SRC_PATH = REPO_ROOT / "src"
+if str(SRC_PATH) not in sys.path:
+    sys.path.insert(0, str(SRC_PATH))
+
+MULTI_AGENT_DIR = REPO_ROOT / "test_examples" / "multi_agent"
+TWOROBOT1D_MULTIAGENT = MULTI_AGENT_DIR / "TwoRobot1D_multiagent.tree"
+TWOROBOT1D_ORIGINAL = REPO_ROOT / "examples" / "MultiAgent" / "TwoRobot1D.tree"
+TWOD_LIVELOCK = MULTI_AGENT_DIR / "2DLivelock_multiagent.tree"
+THREE_IN_RING = MULTI_AGENT_DIR / "ThreeInRing_multiagent.tree"
+FIVE_IN_RING = MULTI_AGENT_DIR / "FiveInRing_multiagent.tree"
+
+
+# ---------------------------------------------------------------------------
+# Import helpers
+# ---------------------------------------------------------------------------
+
+def _import_expander():
+    try:
+        import behaverify.agent_expander as ae
+        return ae
+    except ImportError:
+        pytest.skip("behaverify.agent_expander not importable")
+
+
+def load_metamodel():
+    try:
+        from textx import metamodel_from_file
+    except ImportError:
+        pytest.skip("textx not installed")
+    try:
+        from importlib.resources import files
+        tx_file = files("behaverify").joinpath("data", "metamodel", "behaverify.tx")
+    except Exception:
+        tx_file = SRC_PATH / "behaverify" / "data" / "metamodel" / "behaverify.tx"
+    if not Path(str(tx_file)).exists():
+        pytest.skip("behaverify.tx metamodel not found")
+    return metamodel_from_file(str(tx_file))
+
+
+def require_textx():
+    """Skip the calling test if textx is not importable."""
+    try:
+        import textx  # noqa: F401
+    except ImportError:
+        pytest.skip("textx not installed")
+
+
+def parse_tree_file(path):
+    mm = load_metamodel()
+    return mm.model_from_file(str(path))
+
+
+def parse_and_expand(path):
+    ae = _import_expander()
+    model = parse_tree_file(path)
+    return ae.expand_agents(model)
+
+
+# ---------------------------------------------------------------------------
+# Mock AST builder helpers (no textX required)
+# ---------------------------------------------------------------------------
+# These replicate the attribute shapes that _cs_to_text, _func_to_text, etc.
+# expect from a TextX-parsed model. SimpleNamespace is used so attribute
+# access works identically to real TextX objects.
+
+NS = SimpleNamespace
+
+
+def _cs_ref(name):
+    """code_statement that is an atom.reference (variable name)."""
+    atom = NS(constant=None, reference=name)
+    return NS(
+        agent_param_ref=None, agent_param_index=None, agent_param_name=None,
+        indexed_var=None, indexed_var_index=None, read_at_idx=None,
+        function_call=None, code_statement=None,
+        atom=atom, node_name=None, read_at=None, trace_num=None,
+    )
+
+
+def _cs_int(val):
+    """code_statement that is an atom.constant integer."""
+    atom = NS(constant=NS(val=val), reference=None)
+    return NS(
+        agent_param_ref=None, agent_param_index=None, agent_param_name=None,
+        indexed_var=None, indexed_var_index=None, read_at_idx=None,
+        function_call=None, code_statement=None,
+        atom=atom, node_name=None, read_at=None, trace_num=None,
+    )
+
+
+def _cs_str(val):
+    """code_statement that is an atom.constant string (enum value)."""
+    atom = NS(constant=NS(val=val), reference=None)
+    return NS(
+        agent_param_ref=None, agent_param_index=None, agent_param_name=None,
+        indexed_var=None, indexed_var_index=None, read_at_idx=None,
+        function_call=None, code_statement=None,
+        atom=atom, node_name=None, read_at=None, trace_num=None,
+    )
+
+
+def _cs_indexed(var_name, idx, read_at_idx=None):
+    """code_statement that is an indexed_var (x_pos[i])."""
+    return NS(
+        agent_param_ref=None, agent_param_index=None, agent_param_name=None,
+        indexed_var=var_name, indexed_var_index=idx, read_at_idx=read_at_idx,
+        function_call=None, code_statement=None,
+        atom=None, node_name=None, read_at=None, trace_num=None,
+    )
+
+
+def _cs_agent_param(index_var, param_name):
+    """code_statement that is an agent_param_ref (agents[i].param_name)."""
+    return NS(
+        agent_param_ref='agents', agent_param_index=index_var,
+        agent_param_name=param_name,
+        indexed_var=None, indexed_var_index=None, read_at_idx=None,
+        function_call=None, code_statement=None,
+        atom=None, node_name=None, read_at=None, trace_num=None,
+    )
+
+
+def _cs_func(fname, *values):
+    """code_statement wrapping a regular function call."""
+    func = NS(
+        function_name=fname,
+        values=list(values),
+        loop_variable=None, loop_condition=None, loop_variable_domain=None,
+        min_val=None, max_val=None, reverse=False,
+        bound=None, to_index=None, constant_index=None,
+        node_name=None, read_at=None, trace_num=None,
+        cond_value=None, default_value=None,
+    )
+    return NS(
+        agent_param_ref=None, agent_param_index=None, agent_param_name=None,
+        indexed_var=None, indexed_var_index=None, read_at_idx=None,
+        function_call=func, code_statement=None,
+        atom=None, node_name=None, read_at=None, trace_num=None,
+    )
+
+
+def _cs_status(fname, node_name_cs):
+    """code_statement wrapping a status function (success/failure/running/active)."""
+    func = NS(
+        function_name=fname,
+        values=[],
+        loop_variable=None, loop_condition=None, loop_variable_domain=None,
+        min_val=None, max_val=None, reverse=False,
+        bound=None, to_index=None, constant_index=None,
+        node_name=node_name_cs, read_at=None, trace_num=None,
+        cond_value=None, default_value=None,
+    )
+    return NS(
+        agent_param_ref=None, indexed_var=None, read_at_idx=None,
+        function_call=func, code_statement=None,
+        atom=None, node_name=None, read_at=None, trace_num=None,
+    )
+
+
+def _make_assign(default_values=None, cases=None):
+    """Minimal assign_value mock for _assign_to_text."""
+    case_results = []
+    for cond_cs, val_cs_list in (cases or []):
+        case_results.append(NS(condition=cond_cs, values=val_cs_list))
+    default_result = None
+    if default_values is not None:
+        default_result = NS(values=default_values)
+    return NS(case_results=case_results, default_result=default_result)
+
+
+def _make_domain_range(min_cs, max_cs):
+    return NS(boolean=False, true_int=False, true_real=False,
+              min_val=min_cs, max_val=max_cs, domain_codes=None)
+
+
+def _make_domain_bool():
+    return NS(boolean=True, true_int=False, true_real=False,
+              min_val=None, max_val=None, domain_codes=None)
+
+
+def _make_domain_int():
+    return NS(boolean=False, true_int=True, true_real=False,
+              min_val=None, max_val=None, domain_codes=None)
+
+
+def _make_domain_enum(*codes):
+    return NS(boolean=False, true_int=False, true_real=False,
+              min_val=None, max_val=None, domain_codes=list(codes))
+
+
+def _make_constant(name, val):
+    """Single constant like 'min_val := 0'."""
+    return NS(name=name, val=NS(val=val))
+
+
+def _make_mock_model_constants(**kwargs):
+    """Minimal BehaviorModel mock with just constants and no other attrs."""
+    consts = [_make_constant(k, v) for k, v in kwargs.items()]
+    return NS(constants=consts)

--- a/tests/multi_agent/test_ast_serializers.py
+++ b/tests/multi_agent/test_ast_serializers.py
@@ -1,0 +1,268 @@
+"""
+Pure unit tests for AST-to-text serializers using mock SimpleNamespace nodes.
+
+Tests: _cs_to_text, _func_to_text, _assign_to_text, _domain_to_text
+"""
+
+from types import SimpleNamespace as NS
+
+from .conftest import (
+    _import_expander,
+    _cs_ref, _cs_int, _cs_str, _cs_indexed, _cs_agent_param, _cs_func, _cs_status,
+    _make_assign, _make_domain_range, _make_domain_bool, _make_domain_int, _make_domain_enum,
+)
+
+
+class TestCsToText:
+
+    def setup_method(self):
+        self.ae = _import_expander()
+
+    def test_none_returns_none_string(self):
+        assert self.ae._cs_to_text(None) == 'None'
+
+    def test_atom_reference(self):
+        cs = _cs_ref('x_pos')
+        assert self.ae._cs_to_text(cs) == 'x_pos'
+
+    def test_atom_int_constant(self):
+        cs = _cs_int(42)
+        assert self.ae._cs_to_text(cs) == '42'
+
+    def test_atom_zero_constant(self):
+        cs = _cs_int(0)
+        assert self.ae._cs_to_text(cs) == '0'
+
+    def test_atom_string_constant_quoted(self):
+        cs = _cs_str('Ea')
+        result = self.ae._cs_to_text(cs)
+        assert result == "'Ea'"
+
+    def test_atom_negative_int(self):
+        cs = _cs_int(-1)
+        assert self.ae._cs_to_text(cs) == '-1'
+
+    def test_indexed_var_simple(self):
+        cs = _cs_indexed('x_pos', 'i')
+        assert self.ae._cs_to_text(cs) == 'x_pos[i]'
+
+    def test_indexed_var_self(self):
+        cs = _cs_indexed('x_pos', 'self')
+        assert self.ae._cs_to_text(cs) == 'x_pos[self]'
+
+    def test_indexed_var_with_at(self):
+        at_cs = _cs_int(-1)
+        cs = _cs_indexed('x_pos', 'i', read_at_idx=at_cs)
+        result = self.ae._cs_to_text(cs)
+        assert result == 'x_pos[i] at -1'
+
+    def test_agent_param_ref(self):
+        cs = _cs_agent_param('i', 'start_x')
+        assert self.ae._cs_to_text(cs) == 'agents[i].start_x'
+
+    def test_agent_param_ref_different_param(self):
+        cs = _cs_agent_param('j', 'goal_y')
+        assert self.ae._cs_to_text(cs) == 'agents[j].goal_y'
+
+    def test_function_call_wraps_parens(self):
+        cs = _cs_func('eq', _cs_ref('x'), _cs_int(0))
+        result = self.ae._cs_to_text(cs)
+        assert result.startswith('(')
+        assert result.endswith(')')
+
+    def test_function_call_eq(self):
+        cs = _cs_func('eq', _cs_ref('x'), _cs_int(0))
+        assert self.ae._cs_to_text(cs) == '(eq, x, 0)'
+
+    def test_function_call_add(self):
+        cs = _cs_func('add', _cs_ref('x'), _cs_int(1))
+        assert self.ae._cs_to_text(cs) == '(add, x, 1)'
+
+    def test_function_call_not(self):
+        cs = _cs_func('not', _cs_func('eq', _cs_ref('a'), _cs_ref('b')))
+        result = self.ae._cs_to_text(cs)
+        assert result == '(not, (eq, a, b))'
+
+    def test_function_call_and_two_args(self):
+        cs = _cs_func('and', _cs_func('eq', _cs_ref('a'), _cs_int(1)),
+                              _cs_func('eq', _cs_ref('b'), _cs_int(2)))
+        result = self.ae._cs_to_text(cs)
+        assert result == '(and, (eq, a, 1), (eq, b, 2))'
+
+    def test_status_function_success(self):
+        cs = _cs_status('success', _cs_ref('MyNode'))
+        result = self.ae._cs_to_text(cs)
+        assert result == '(success, MyNode)'
+
+    def test_status_function_failure(self):
+        cs = _cs_status('failure', _cs_ref('RobotRoot'))
+        result = self.ae._cs_to_text(cs)
+        assert result == '(failure, RobotRoot)'
+
+
+class TestFuncToText:
+
+    def setup_method(self):
+        self.ae = _import_expander()
+
+    def _make_func(self, fname, *values):
+        return NS(
+            function_name=fname, values=list(values),
+            loop_variable=None, loop_condition=None, loop_variable_domain=None,
+            min_val=None, max_val=None, reverse=False,
+            bound=None, to_index=None, constant_index=None,
+            node_name=None, read_at=None, trace_num=None,
+            cond_value=None, default_value=None,
+        )
+
+    def test_regular_binary_function(self):
+        func = self._make_func('eq', _cs_ref('x'), _cs_int(0))
+        assert self.ae._func_to_text(func) == 'eq, x, 0'
+
+    def test_regular_unary_function(self):
+        func = self._make_func('neg', _cs_ref('x'))
+        assert self.ae._func_to_text(func) == 'neg, x'
+
+    def test_regular_ternary_function(self):
+        func = self._make_func('if', _cs_ref('c'), _cs_int(1), _cs_int(0))
+        assert self.ae._func_to_text(func) == 'if, c, 1, 0'
+
+    def test_forall_function(self):
+        func = self._make_func('forall', _cs_ref('i'), _cs_ref('agents'), _cs_ref('body'))
+        result = self.ae._func_to_text(func)
+        assert result.startswith('forall,')
+        assert 'i' in result
+        assert 'agents' in result
+
+    def test_exists_function(self):
+        func = self._make_func('exists', _cs_ref('i'), _cs_ref('agents'), _cs_ref('body'))
+        result = self.ae._func_to_text(func)
+        assert result.startswith('exists,')
+
+    def test_always_globally_function(self):
+        func = self._make_func('always_globally', _cs_ref('p'))
+        assert self.ae._func_to_text(func) == 'always_globally, p'
+
+    def test_status_success(self):
+        func = NS(
+            function_name='success', values=[],
+            node_name=_cs_ref('MyNode'),
+            loop_variable=None, loop_condition=None, loop_variable_domain=None,
+            min_val=None, max_val=None, reverse=False,
+            bound=None, to_index=None, constant_index=None,
+            read_at=None, trace_num=None,
+            cond_value=None, default_value=None,
+        )
+        assert self.ae._func_to_text(func) == 'success, MyNode'
+
+    def test_status_running(self):
+        func = NS(
+            function_name='running', values=[],
+            node_name=_cs_ref('RootNode'),
+            loop_variable=None, loop_condition=None, loop_variable_domain=None,
+            min_val=None, max_val=None, reverse=False,
+            bound=None, to_index=None, constant_index=None,
+            read_at=None, trace_num=None,
+            cond_value=None, default_value=None,
+        )
+        assert self.ae._func_to_text(func) == 'running, RootNode'
+
+    def test_no_args_function(self):
+        func = self._make_func('True')
+        assert self.ae._func_to_text(func) == 'True, '
+
+
+class TestAssignToText:
+
+    def setup_method(self):
+        self.ae = _import_expander()
+
+    def test_simple_default_result(self):
+        assign = _make_assign(default_values=[_cs_str('XX')])
+        text = self.ae._assign_to_text(assign)
+        assert "assign{" in text
+        assert "result {" in text
+        assert "'XX'" in text
+
+    def test_int_default_result(self):
+        assign = _make_assign(default_values=[_cs_int(0)])
+        text = self.ae._assign_to_text(assign)
+        assert "result {0}" in text or "result { 0}" in text
+
+    def test_case_and_default(self):
+        cond = _cs_func('eq', _cs_ref('act'), _cs_str('Ea'))
+        assign = _make_assign(
+            cases=[(cond, [_cs_int(1)])],
+            default_values=[_cs_int(0)],
+        )
+        text = self.ae._assign_to_text(assign)
+        assert "case {" in text
+        assert "'Ea'" in text
+        assert "result {1}" in text or "result { 1}" in text
+        assert "result {0}" in text or "result { 0}" in text
+
+    def test_multiple_cases(self):
+        c1 = _cs_func('eq', _cs_ref('act'), _cs_str('We'))
+        c2 = _cs_func('eq', _cs_ref('act'), _cs_str('Ea'))
+        assign = _make_assign(
+            cases=[(c1, [_cs_int(0)]), (c2, [_cs_int(1)])],
+            default_values=[_cs_ref('x')],
+        )
+        text = self.ae._assign_to_text(assign)
+        assert text.count("case {") == 2
+        assert "'We'" in text
+        assert "'Ea'" in text
+
+    def test_none_assign_returns_fallback(self):
+        text = self.ae._assign_to_text(None)
+        assert "assign{" in text
+        assert "result{0}" in text
+
+    def test_result_with_multiple_values(self):
+        assign = _make_assign(default_values=[_cs_str('We'), _cs_str('Ea')])
+        text = self.ae._assign_to_text(assign)
+        assert "'We'" in text
+        assert "'Ea'" in text
+
+
+class TestDomainToText:
+
+    def setup_method(self):
+        self.ae = _import_expander()
+
+    def test_boolean_domain(self):
+        domain = _make_domain_bool()
+        assert self.ae._domain_to_text(domain) == 'BOOLEAN'
+
+    def test_int_domain(self):
+        domain = _make_domain_int()
+        assert self.ae._domain_to_text(domain) == 'INT'
+
+    def test_range_domain(self):
+        domain = _make_domain_range(_cs_int(0), _cs_int(4))
+        result = self.ae._domain_to_text(domain)
+        assert result == '[0, 4]'
+
+    def test_range_domain_negative(self):
+        domain = _make_domain_range(_cs_int(-5), _cs_int(5))
+        result = self.ae._domain_to_text(domain)
+        assert '-5' in result
+        assert '5' in result
+
+    def test_enum_domain(self):
+        domain = _make_domain_enum(_cs_str('We'), _cs_str('Ea'), _cs_str('XX'))
+        result = self.ae._domain_to_text(domain)
+        assert "'We'" in result
+        assert "'Ea'" in result
+        assert "'XX'" in result
+        assert result.startswith('{')
+        assert result.endswith('}')
+
+    def test_none_domain_returns_int(self):
+        assert self.ae._domain_to_text(None) == 'INT'
+
+    def test_range_domain_with_ref(self):
+        domain = _make_domain_range(_cs_ref('min_val'), _cs_ref('max_val'))
+        result = self.ae._domain_to_text(domain)
+        assert 'min_val' in result
+        assert 'max_val' in result

--- a/tests/multi_agent/test_data_classes.py
+++ b/tests/multi_agent/test_data_classes.py
@@ -1,0 +1,249 @@
+"""
+Pure unit tests for ExpandedModel data classes and model_to_tree_text serialization.
+
+Tests: ExpandedVariable, ExpandedCheck, ExpandedAction, ExpandedTreeNode,
+       ExpandedSpec, ExpandedModel, model_to_tree_text
+"""
+
+from .conftest import _import_expander
+
+
+class TestDataClasses:
+
+    def setup_method(self):
+        self.ae = _import_expander()
+
+    def test_expanded_variable_numeric_initial(self):
+        ev = self.ae.ExpandedVariable("x_pos_r0", "env", "[0, 4]", initial_value=0)
+        text = ev.to_tree_text()
+        assert "env" in text
+        assert "x_pos_r0" in text
+        assert "[0, 4]" in text
+        assert "0" in text
+
+    def test_expanded_variable_string_initial(self):
+        ev = self.ae.ExpandedVariable("act_r0", "bl", "{'We','Ea','XX'}", initial_value="XX")
+        text = ev.to_tree_text()
+        assert "bl" in text
+        assert "act_r0" in text
+        assert "'XX'" in text
+
+    def test_expanded_variable_initial_text_overrides(self):
+        ev = self.ae.ExpandedVariable(
+            "act_r0", "bl", "{'We','Ea','XX'}",
+            initial_value=0,
+            initial_text="assign{result{'XX'}}"
+        )
+        text = ev.to_tree_text()
+        assert "assign{result{'XX'}}" in text
+
+    def test_expanded_variable_format(self):
+        ev = self.ae.ExpandedVariable("x_pos_r0", "env", "[0, 4]", initial_value=2)
+        text = ev.to_tree_text()
+        assert text.startswith("variable {")
+        assert "VAR" in text
+        assert "assign{" in text
+
+    def test_expanded_check_to_text_content(self):
+        ck = self.ae.ExpandedCheck(
+            "AtGoal_r0", "(eq, x_pos_r0, 4)", read_vars=["x_pos_r0"]
+        )
+        text = ck.to_tree_text()
+        assert "AtGoal_r0" in text
+        assert "(eq, x_pos_r0, 4)" in text
+        assert "x_pos_r0" in text
+
+    def test_expanded_check_to_text_format(self):
+        ck = self.ae.ExpandedCheck("C", "(True)")
+        text = ck.to_tree_text()
+        assert "environment_check {" in text
+        assert "arguments {}" in text
+        assert "condition {" in text
+
+    def test_expanded_check_empty_read_vars(self):
+        ck = self.ae.ExpandedCheck("MyCheck", "(True)")
+        text = ck.to_tree_text()
+        assert "MyCheck" in text
+        assert "(True)" in text
+        assert "read_variables {}" in text
+
+    def test_expanded_action_to_text_content(self):
+        act = self.ae.ExpandedAction(
+            "Move_r0", ["act_r0"],
+            "return_statement {result{success}}"
+        )
+        text = act.to_tree_text()
+        assert "Move_r0" in text
+        assert "act_r0" in text
+        assert "write_variables" in text
+
+    def test_expanded_action_to_text_format(self):
+        act = self.ae.ExpandedAction("Move_r0", [], "return_statement {result{success}}")
+        text = act.to_tree_text()
+        assert "action {" in text
+        assert "arguments {}" in text
+        assert "update {" in text
+
+    def test_expanded_tree_node_leaf(self):
+        node = self.ae.ExpandedTreeNode(
+            node_type='leaf', name='AtGoal_r0', leaf_name='AtGoal_r0'
+        )
+        text = node.to_tree_text(4)
+        assert "AtGoal_r0 {}" in text
+
+    def test_expanded_tree_node_leaf_indented(self):
+        node = self.ae.ExpandedTreeNode(
+            node_type='leaf', name='L', leaf_name='L'
+        )
+        text = node.to_tree_text(8)
+        assert text.startswith("        ")  # 8 spaces
+
+    def test_expanded_tree_node_parallel_content(self):
+        child = self.ae.ExpandedTreeNode(
+            node_type='leaf', name='L', leaf_name='L'
+        )
+        root = self.ae.ExpandedTreeNode(
+            node_type='parallel', name='Root',
+            children=[child], parallel_policy='success_on_all'
+        )
+        text = root.to_tree_text(4)
+        assert "parallel" in text
+        assert "success_on_all" in text
+        assert "Root" in text
+        assert "L {}" in text
+
+    def test_expanded_tree_node_selector(self):
+        child = self.ae.ExpandedTreeNode(node_type='leaf', name='L', leaf_name='L')
+        node = self.ae.ExpandedTreeNode(
+            node_type='selector', name='MySelector', children=[child]
+        )
+        text = node.to_tree_text(4)
+        assert "selector" in text
+        assert "MySelector" in text
+
+    def test_expanded_tree_node_sequence(self):
+        child = self.ae.ExpandedTreeNode(node_type='leaf', name='L', leaf_name='L')
+        node = self.ae.ExpandedTreeNode(
+            node_type='sequence', name='MySeq', children=[child]
+        )
+        text = node.to_tree_text(4)
+        assert "sequence" in text
+        assert "MySeq" in text
+
+    def test_expanded_spec_invarspec(self):
+        spec = self.ae.ExpandedSpec("INVARSPEC", "(eq, x, 0)")
+        assert str(spec) == "INVARSPEC {(eq, x, 0)}"
+
+    def test_expanded_spec_ctlspec(self):
+        spec = self.ae.ExpandedSpec("CTLSPEC", "(always_globally, (eq, x, 0))")
+        assert str(spec) == "CTLSPEC {(always_globally, (eq, x, 0))}"
+
+    def test_expanded_spec_ltlspec(self):
+        spec = self.ae.ExpandedSpec("LTLSPEC", "(globally, (eq, x, 0))")
+        assert str(spec) == "LTLSPEC {(globally, (eq, x, 0))}"
+
+
+class TestModelSerialization:
+
+    def setup_method(self):
+        self.ae = _import_expander()
+
+    def _build_model(self):
+        ae = self.ae
+        expanded = ae.ExpandedModel()
+        expanded.enumerations = ["We", "Ea"]
+        expanded.constants_text = "max_val := 4"
+        expanded.variables = [
+            ae.ExpandedVariable("x_r0", "env", "[0, 4]", initial_value=0),
+        ]
+        expanded.environment_checks = [
+            ae.ExpandedCheck("AtGoal_r0", "(eq, x_r0, 4)"),
+        ]
+        expanded.action_nodes = [
+            ae.ExpandedAction("Move_r0", [], "return_statement {result{success}}"),
+        ]
+        leaf = ae.ExpandedTreeNode(node_type='leaf', name='Move_r0', leaf_name='Move_r0')
+        expanded.tree = ae.ExpandedTreeNode(
+            node_type='parallel', name='Root', children=[leaf]
+        )
+        expanded.tick_prerequisite_text = '(True)'
+        expanded.specifications = [
+            ae.ExpandedSpec("INVARSPEC", "(eq, x_r0, 0)"),
+        ]
+        return expanded
+
+    def test_configuration_section_present(self):
+        text = self.ae.model_to_tree_text(self._build_model())
+        assert "configuration {" in text
+
+    def test_enumerations_section_present(self):
+        text = self.ae.model_to_tree_text(self._build_model())
+        assert "enumerations {" in text
+
+    def test_constants_section_present(self):
+        text = self.ae.model_to_tree_text(self._build_model())
+        assert "constants {" in text
+
+    def test_section_order_config_before_variables(self):
+        text = self.ae.model_to_tree_text(self._build_model())
+        assert text.index("configuration") < text.index("variables {")
+
+    def test_section_order_variables_before_env_update(self):
+        text = self.ae.model_to_tree_text(self._build_model())
+        assert text.index("variables {") < text.index("environment_update {")
+
+    def test_section_order_checks_before_env_checks(self):
+        text = self.ae.model_to_tree_text(self._build_model())
+        assert text.index("\nchecks {}") < text.index("environment_checks {")
+
+    def test_section_order_actions_before_subtrees(self):
+        text = self.ae.model_to_tree_text(self._build_model())
+        assert text.index("actions {") < text.index("sub_trees {}")
+
+    def test_section_order_tree_before_tick(self):
+        text = self.ae.model_to_tree_text(self._build_model())
+        assert text.index("tree {") < text.index("tick_prerequisite {")
+
+    def test_section_order_tick_before_specs(self):
+        text = self.ae.model_to_tree_text(self._build_model())
+        assert text.index("tick_prerequisite {") < text.index("specifications {")
+
+    def test_variable_name_in_output(self):
+        text = self.ae.model_to_tree_text(self._build_model())
+        assert "x_r0" in text
+
+    def test_check_name_in_output(self):
+        text = self.ae.model_to_tree_text(self._build_model())
+        assert "AtGoal_r0" in text
+
+    def test_action_name_in_output(self):
+        text = self.ae.model_to_tree_text(self._build_model())
+        assert "Move_r0" in text
+
+    def test_spec_in_output(self):
+        text = self.ae.model_to_tree_text(self._build_model())
+        assert "INVARSPEC" in text
+        assert "(eq, x_r0, 0)" in text
+
+    def test_no_agent_array_syntax(self):
+        text = self.ae.model_to_tree_text(self._build_model())
+        assert "[agents]" not in text
+        assert "agents[i]" not in text
+        assert "[self]" not in text
+
+    def test_no_agent_types_section(self):
+        text = self.ae.model_to_tree_text(self._build_model())
+        assert "agent_types {" not in text
+        assert "agent_type {" not in text
+
+    def test_no_agents_section(self):
+        text = self.ae.model_to_tree_text(self._build_model())
+        assert "\nagents {" not in text
+
+    def test_parallel_node_in_tree(self):
+        text = self.ae.model_to_tree_text(self._build_model())
+        assert "parallel" in text
+
+    def test_tick_prerequisite_value(self):
+        text = self.ae.model_to_tree_text(self._build_model())
+        assert "tick_prerequisite {(True)}" in text

--- a/tests/multi_agent/test_expansion_logic.py
+++ b/tests/multi_agent/test_expansion_logic.py
@@ -1,0 +1,301 @@
+"""
+Pure unit tests for expansion logic helpers.
+
+Tests: _build_agent_subs, _substitute_agent_in_body,
+       _try_extract_top_forall, _expand_spec_body, _resolve_constants
+"""
+
+from types import SimpleNamespace as NS
+
+from .conftest import (
+    _import_expander,
+    _cs_ref, _cs_int,
+    _make_mock_model_constants,
+)
+
+
+class TestBuildAgentSubs:
+
+    def setup_method(self):
+        self.ae = _import_expander()
+
+    def test_env_array_self_substitution(self):
+        subs = self.ae._build_agent_subs(
+            'r0', agent_vars=[], env_arrays=['x_pos'], consts={}, params={}
+        )
+        assert subs['x_pos[self]'] == 'x_pos_r0'
+
+    def test_multiple_env_arrays(self):
+        subs = self.ae._build_agent_subs(
+            'r1', agent_vars=[], env_arrays=['x_pos', 'y_pos'], consts={}, params={}
+        )
+        assert subs['x_pos[self]'] == 'x_pos_r1'
+        assert subs['y_pos[self]'] == 'y_pos_r1'
+
+    def test_agent_local_var_suffixed(self):
+        subs = self.ae._build_agent_subs(
+            'r0', agent_vars=['act'], env_arrays=[], consts={}, params={}
+        )
+        assert subs['act'] == 'act_r0'
+
+    def test_multiple_agent_local_vars(self):
+        subs = self.ae._build_agent_subs(
+            'r2', agent_vars=['act', 'mode'], env_arrays=[], consts={}, params={}
+        )
+        assert subs['act'] == 'act_r2'
+        assert subs['mode'] == 'mode_r2'
+
+    def test_parameter_substitution(self):
+        subs = self.ae._build_agent_subs(
+            'r0', agent_vars=[], env_arrays=[], consts={},
+            params={'goal_x': 4, 'start_x': 0}
+        )
+        assert subs['goal_x'] == '4'
+        assert subs['start_x'] == '0'
+
+    def test_combined_subs(self):
+        subs = self.ae._build_agent_subs(
+            'r1',
+            agent_vars=['act'],
+            env_arrays=['x_pos'],
+            consts={'min_val': 0},
+            params={'goal_x': 0}
+        )
+        assert subs['x_pos[self]'] == 'x_pos_r1'
+        assert subs['act'] == 'act_r1'
+        assert subs['goal_x'] == '0'
+
+    def test_different_agent_names(self):
+        subs_r0 = self.ae._build_agent_subs('r0', ['act'], ['x_pos'], {}, {})
+        subs_r5 = self.ae._build_agent_subs('r5', ['act'], ['x_pos'], {}, {})
+        assert subs_r0['act'] == 'act_r0'
+        assert subs_r5['act'] == 'act_r5'
+        assert subs_r0['x_pos[self]'] == 'x_pos_r0'
+        assert subs_r5['x_pos[self]'] == 'x_pos_r5'
+
+
+class TestSubstituteAgentInBody:
+
+    def setup_method(self):
+        self.ae = _import_expander()
+
+    def _sub(self, body, var='i', agent='r0', env_arrays=None,
+             agent_local_vars=None, agent_params=None):
+        env_arrays = env_arrays or []
+        agent_local_vars = agent_local_vars or []
+        agent_params = agent_params or {}
+        return self.ae._substitute_agent_in_body(
+            body, var, agent, env_arrays, agent_local_vars, agent_params, {}
+        )
+
+    def test_env_array_indexed_substituted(self):
+        result = self._sub('x_pos[i]', env_arrays=['x_pos'])
+        assert result == 'x_pos_r0'
+
+    def test_env_array_in_expression(self):
+        result = self._sub('(eq, x_pos[i], 4)', env_arrays=['x_pos'])
+        assert 'x_pos_r0' in result
+        assert 'x_pos[i]' not in result
+
+    def test_env_array_with_at(self):
+        result = self._sub('x_pos[i] at -1', env_arrays=['x_pos'])
+        assert 'x_pos_r0 at -1' in result
+
+    def test_parameter_indexed_substituted(self):
+        result = self._sub('goal_x[i]',
+                           agent_params={'r0': {'goal_x': 4}})
+        assert result == '4'
+
+    def test_string_parameter_quoted(self):
+        result = self._sub('dir[i]',
+                           agent_params={'r0': {'dir': 'Ea'}})
+        assert result == "'Ea'"
+
+    def test_bare_index_var_in_neq(self):
+        result = self._sub('(neq, i, j)')
+        assert 'r0' in result
+        assert ', i,' not in result
+
+    def test_bare_index_var_at_end(self):
+        result = self._sub('(eq, x, i)')
+        assert 'r0' in result
+        assert ', i)' not in result
+
+    def test_multiple_env_arrays(self):
+        result = self._sub(
+            '(and, (eq, x_pos[i], 0), (eq, y_pos[i], 1))',
+            env_arrays=['x_pos', 'y_pos']
+        )
+        assert 'x_pos_r0' in result
+        assert 'y_pos_r0' in result
+
+    def test_different_agent_name(self):
+        result = self._sub('x_pos[i]', agent='r3', env_arrays=['x_pos'])
+        assert result == 'x_pos_r3'
+
+    def test_no_match_passthrough(self):
+        body = '(eq, a, b)'
+        result = self._sub(body)
+        assert result == body
+
+
+class TestTryExtractTopForall:
+
+    def setup_method(self):
+        self.ae = _import_expander()
+
+    def test_valid_forall_over_agents(self):
+        text = '(forall, i, agents, (eq, x, 0))'
+        result = self.ae._try_extract_top_forall(text)
+        assert result is not None
+        quant, var, domain, body = result
+        assert quant == 'forall'
+        assert var == 'i'
+        assert domain == 'agents'
+        assert '(eq, x, 0)' in body
+
+    def test_valid_exists_over_agents(self):
+        text = '(exists, i, agents, (eq, x, 0))'
+        result = self.ae._try_extract_top_forall(text)
+        assert result is not None
+        assert result[0] == 'exists'
+
+    def test_non_quantifier_function_returns_none(self):
+        text = '(always_globally, (eq, x, 0))'
+        assert self.ae._try_extract_top_forall(text) is None
+
+    def test_no_outer_parens_returns_none(self):
+        assert self.ae._try_extract_top_forall('forall, i, agents, x') is None
+
+    def test_too_few_parts_returns_none(self):
+        assert self.ae._try_extract_top_forall('(forall, i, agents)') is None
+
+    def test_non_agents_domain_still_parsed(self):
+        text = '(forall, i, mylist, (eq, x, 0))'
+        result = self.ae._try_extract_top_forall(text)
+        assert result is not None
+        assert result[2] == 'mylist'
+
+    def test_nested_body_preserved(self):
+        text = '(forall, i, agents, (always_globally, (exists_finally, (eq, x, 0))))'
+        result = self.ae._try_extract_top_forall(text)
+        assert result is not None
+        _, _, _, body = result
+        assert 'always_globally' in body
+        assert 'exists_finally' in body
+
+    def test_empty_string_returns_none(self):
+        assert self.ae._try_extract_top_forall('') is None
+
+    def test_plain_atom_returns_none(self):
+        assert self.ae._try_extract_top_forall('x_pos_r0') is None
+
+
+class TestExpandSpecBody:
+
+    def setup_method(self):
+        self.ae = _import_expander()
+
+    def _expand(self, text, agent_names=None, env_arrays=None, agent_params=None):
+        agent_names = agent_names or ['r0', 'r1']
+        env_arrays = env_arrays or {}
+        agent_params = agent_params or {n: {} for n in agent_names}
+        return self.ae._expand_spec_body(
+            text, agent_names, env_arrays, [], agent_params, {}
+        )
+
+    def test_forall_over_agents_becomes_and(self):
+        text = '(forall, i, agents, (eq, x_pos[i], 0))'
+        result = self._expand(text, env_arrays={'x_pos': {}})
+        assert result.startswith('(and,')
+        assert 'x_pos_r0' in result
+        assert 'x_pos_r1' in result
+
+    def test_exists_over_agents_becomes_or(self):
+        text = '(exists, i, agents, (eq, x_pos[i], 0))'
+        result = self._expand(text, env_arrays={'x_pos': {}})
+        assert result.startswith('(or,')
+
+    def test_no_quantifier_passthrough(self):
+        text = '(eq, x_pos_r0 at -1, 4)'
+        result = self._expand(text)
+        assert result == text
+
+    def test_three_agents_forall(self):
+        result = self._expand(
+            '(forall, i, agents, P)',
+            agent_names=['r0', 'r1', 'r2']
+        )
+        assert result.startswith('(and,')
+        assert result.count('P') == 3
+
+    def test_nested_forall_fully_expanded(self):
+        text = '(forall, i, agents, (forall, j, agents, (neq, x_pos[i], x_pos[j])))'
+        result = self._expand(text, env_arrays={'x_pos': {}})
+        assert 'forall' not in result
+        assert 'x_pos_r0' in result
+        assert 'x_pos_r1' in result
+
+    def test_single_agent_forall_no_and_wrapper(self):
+        result = self._expand(
+            '(forall, i, agents, (eq, x_pos[i], 0))',
+            agent_names=['r0'],
+            env_arrays={'x_pos': {}}
+        )
+        assert 'x_pos_r0' in result
+        assert 'x_pos_r1' not in result
+
+    def test_domain_other_than_agents_not_expanded(self):
+        text = '(forall, i, mylist, (eq, x, 0))'
+        result = self._expand(text)
+        assert result == text
+
+
+class TestResolveConstants:
+
+    def setup_method(self):
+        self.ae = _import_expander()
+
+    def test_int_constant_with_val_wrapper(self):
+        model = _make_mock_model_constants(min_val=0, max_val=4)
+        consts = self.ae._resolve_constants(model)
+        assert consts['min_val'] == 0
+        assert consts['max_val'] == 4
+
+    def test_multiple_constants(self):
+        model = _make_mock_model_constants(a=1, b=2, c=3)
+        consts = self.ae._resolve_constants(model)
+        assert consts == {'a': 1, 'b': 2, 'c': 3}
+
+    def test_zero_constant(self):
+        model = _make_mock_model_constants(zero=0)
+        consts = self.ae._resolve_constants(model)
+        assert consts['zero'] == 0
+
+    def test_negative_constant(self):
+        model = _make_mock_model_constants(neg=NS(val=-5))
+        consts = self.ae._resolve_constants(model)
+        assert 'neg' in consts
+
+    def test_empty_constants(self):
+        model = NS(constants=[])
+        consts = self.ae._resolve_constants(model)
+        assert consts == {}
+
+    def test_resolve_value_constant(self):
+        value_obj = NS(constant=NS(val=4), reference=None)
+        result = self.ae._resolve_value(value_obj, {})
+        assert result == 4
+
+    def test_resolve_value_reference_to_constant(self):
+        value_obj = NS(constant=None, reference='max_val')
+        result = self.ae._resolve_value(value_obj, {'max_val': 4})
+        assert result == 4
+
+    def test_resolve_value_unknown_reference(self):
+        value_obj = NS(constant=None, reference='unknown')
+        result = self.ae._resolve_value(value_obj, {})
+        assert result == 'unknown'
+
+    def test_resolve_value_none(self):
+        assert self.ae._resolve_value(None, {}) is None

--- a/tests/multi_agent/test_integration.py
+++ b/tests/multi_agent/test_integration.py
@@ -1,0 +1,585 @@
+"""
+Integration tests for the multi-agent expander (textX required).
+
+All tests skip gracefully when textX is not installed.
+
+Tests: TestExpanderVariableExpansion, TestExpanderEnvUpdate,
+       TestExpanderChecksActions, TestExpanderTree, TestExpanderSpecs,
+       TestMultiAgentScenarios, TestMaybeExpand
+"""
+
+from pathlib import Path
+import pytest
+
+from .conftest import (
+    _import_expander, load_metamodel, require_textx, parse_tree_file,
+    parse_and_expand,
+    TWOROBOT1D_MULTIAGENT, TWOROBOT1D_ORIGINAL,
+    TWOD_LIVELOCK, THREE_IN_RING, FIVE_IN_RING,
+)
+
+
+class TestExpanderVariableExpansion:
+
+    @pytest.fixture(autouse=True)
+    def setup_expanded(self):
+        self._expanded = parse_and_expand(TWOROBOT1D_MULTIAGENT)
+
+    def test_total_variable_count(self):
+        # 2 env (x_pos_r0, x_pos_r1) + 2 bl (act_r0, act_r1) = 4
+        assert len(self._expanded.variables) == 4
+
+    def test_two_env_vars_exist(self):
+        env_names = {v.name for v in self._expanded.variables if v.scope == "env"}
+        assert len(env_names) == 2
+
+    def test_env_var_names_are_x_pos_r0_and_r1(self):
+        env_names = {v.name for v in self._expanded.variables if v.scope == "env"}
+        assert "x_pos_r0" in env_names
+        assert "x_pos_r1" in env_names
+
+    def test_two_bl_vars_exist(self):
+        bl_names = {v.name for v in self._expanded.variables if v.scope == "bl"}
+        assert len(bl_names) == 2
+
+    def test_bl_var_names_are_act_r0_and_r1(self):
+        bl_names = {v.name for v in self._expanded.variables if v.scope == "bl"}
+        assert "act_r0" in bl_names
+        assert "act_r1" in bl_names
+
+    def test_x_pos_r0_initial_value_is_zero(self):
+        env_map = {v.name: v for v in self._expanded.variables if v.scope == "env"}
+        assert env_map["x_pos_r0"].initial_value == 0
+
+    def test_x_pos_r1_initial_value_is_four(self):
+        env_map = {v.name: v for v in self._expanded.variables if v.scope == "env"}
+        assert env_map["x_pos_r1"].initial_value == 4
+
+    def test_env_var_domain_is_range(self):
+        # Domain text is a range like [min_val, max_val] or [0, 4]
+        env_map = {v.name: v for v in self._expanded.variables if v.scope == "env"}
+        domain = env_map["x_pos_r0"].domain_text
+        assert domain.startswith("[")
+        assert domain.endswith("]")
+
+    def test_bl_var_has_initial_text_not_value(self):
+        bl_map = {v.name: v for v in self._expanded.variables if v.scope == "bl"}
+        assert bl_map["act_r0"].initial_text is not None
+        assert len(bl_map["act_r0"].initial_text) > 0
+
+    def test_bl_var_initial_text_contains_assign(self):
+        bl_map = {v.name: v for v in self._expanded.variables if v.scope == "bl"}
+        assert "assign" in bl_map["act_r0"].initial_text
+
+    def test_no_agent_types_remain(self):
+        assert len(self._expanded.agent_types) == 0
+
+    def test_no_array_syntax_in_var_names(self):
+        for v in self._expanded.variables:
+            assert "[" not in v.name
+            assert "]" not in v.name
+
+
+class TestExpanderEnvUpdate:
+
+    @pytest.fixture(autouse=True)
+    def setup_expanded(self):
+        self._expanded = parse_and_expand(TWOROBOT1D_MULTIAGENT)
+
+    def test_env_update_not_empty(self):
+        assert len(self._expanded.environment_update_text.strip()) > 0
+
+    def test_env_update_has_x_pos_r0(self):
+        assert "x_pos_r0" in self._expanded.environment_update_text
+
+    def test_env_update_has_x_pos_r1(self):
+        assert "x_pos_r1" in self._expanded.environment_update_text
+
+    def test_env_update_no_index_loop_x_pos(self):
+        assert "x_pos[i]" not in self._expanded.environment_update_text
+
+    def test_env_update_no_index_loop_act(self):
+        assert "act[i]" not in self._expanded.environment_update_text
+
+    def test_env_update_r0_section_references_act_r0(self):
+        text = self._expanded.environment_update_text
+        r0_idx = text.find("x_pos_r0")
+        r1_idx = text.find("x_pos_r1")
+        assert r0_idx != -1 and r1_idx != -1
+        r0_segment = text[r0_idx:r1_idx]
+        assert "act_r0" in r0_segment
+
+    def test_env_update_preserves_direction_constants(self):
+        text = self._expanded.environment_update_text
+        assert "'We'" in text
+        assert "'Ea'" in text
+
+    def test_env_update_has_two_variable_statements(self):
+        count = self._expanded.environment_update_text.count("variable_statement")
+        assert count == 2
+
+    def test_env_update_has_case_expressions(self):
+        assert "case {" in self._expanded.environment_update_text
+
+
+class TestExpanderChecksActions:
+
+    @pytest.fixture(autouse=True)
+    def setup_expanded(self):
+        self._expanded = parse_and_expand(TWOROBOT1D_MULTIAGENT)
+
+    def test_two_checks_created(self):
+        assert len(self._expanded.environment_checks) == 2
+
+    def test_check_names_suffixed_r0(self):
+        names = {ck.name for ck in self._expanded.environment_checks}
+        assert "AtGoal_r0" in names
+
+    def test_check_names_suffixed_r1(self):
+        names = {ck.name for ck in self._expanded.environment_checks}
+        assert "AtGoal_r1" in names
+
+    def test_check_r0_condition_has_x_pos_r0(self):
+        ck_map = {ck.name: ck for ck in self._expanded.environment_checks}
+        assert "x_pos_r0" in ck_map["AtGoal_r0"].condition_text
+
+    def test_check_r0_condition_no_self_reference(self):
+        ck_map = {ck.name: ck for ck in self._expanded.environment_checks}
+        assert "[self]" not in ck_map["AtGoal_r0"].condition_text
+
+    def test_check_r0_goal_x_resolved_to_4(self):
+        ck_map = {ck.name: ck for ck in self._expanded.environment_checks}
+        assert "4" in ck_map["AtGoal_r0"].condition_text
+        assert "goal_x" not in ck_map["AtGoal_r0"].condition_text
+
+    def test_check_r1_goal_x_resolved_to_0(self):
+        ck_map = {ck.name: ck for ck in self._expanded.environment_checks}
+        assert "0" in ck_map["AtGoal_r1"].condition_text
+        assert "goal_x" not in ck_map["AtGoal_r1"].condition_text
+
+    def test_check_r0_read_vars_use_flat_name(self):
+        ck_map = {ck.name: ck for ck in self._expanded.environment_checks}
+        assert any("x_pos_r0" in rv for rv in ck_map["AtGoal_r0"].read_vars)
+
+    def test_check_r1_read_vars_use_flat_name(self):
+        ck_map = {ck.name: ck for ck in self._expanded.environment_checks}
+        assert any("x_pos_r1" in rv for rv in ck_map["AtGoal_r1"].read_vars)
+
+    def test_two_actions_created(self):
+        assert len(self._expanded.action_nodes) == 2
+
+    def test_action_names_suffixed_r0(self):
+        names = {a.name for a in self._expanded.action_nodes}
+        assert "Move_r0" in names
+
+    def test_action_names_suffixed_r1(self):
+        names = {a.name for a in self._expanded.action_nodes}
+        assert "Move_r1" in names
+
+    def test_action_r0_write_vars_is_act_r0(self):
+        act_map = {a.name: a for a in self._expanded.action_nodes}
+        assert "act_r0" in act_map["Move_r0"].write_vars
+
+    def test_action_r1_write_vars_is_act_r1(self):
+        act_map = {a.name: a for a in self._expanded.action_nodes}
+        assert "act_r1" in act_map["Move_r1"].write_vars
+
+    def test_action_update_text_no_bare_act_token(self):
+        for act in self._expanded.action_nodes:
+            tokens = act.update_text.split()
+            assert "act" not in tokens
+
+
+class TestExpanderTree:
+
+    @pytest.fixture(autouse=True)
+    def setup_expanded(self):
+        self._expanded = parse_and_expand(TWOROBOT1D_MULTIAGENT)
+
+    def test_root_node_type_is_parallel(self):
+        assert self._expanded.tree.node_type == "parallel"
+
+    def test_root_name_is_root(self):
+        assert self._expanded.tree.name == "Root"
+
+    def test_root_has_two_children(self):
+        assert len(self._expanded.tree.children) == 2
+
+    def test_r0_subtree_present(self):
+        child_names = {c.name for c in self._expanded.tree.children}
+        assert "RobotRoot_r0" in child_names
+
+    def test_r1_subtree_present(self):
+        child_names = {c.name for c in self._expanded.tree.children}
+        assert "RobotRoot_r1" in child_names
+
+    def test_r0_subtree_is_selector(self):
+        child_map = {c.name: c for c in self._expanded.tree.children}
+        assert child_map["RobotRoot_r0"].node_type == "selector"
+
+    def test_r0_subtree_contains_atgoal_r0_leaf(self):
+        def collect_leaves(node):
+            if node.node_type == 'leaf':
+                return {node.leaf_name}
+            names = set()
+            for c in node.children:
+                names |= collect_leaves(c)
+            return names
+
+        child_map = {c.name: c for c in self._expanded.tree.children}
+        leaves = collect_leaves(child_map["RobotRoot_r0"])
+        assert "AtGoal_r0" in leaves
+
+    def test_r0_subtree_contains_move_r0_leaf(self):
+        def collect_leaves(node):
+            if node.node_type == 'leaf':
+                return {node.leaf_name}
+            names = set()
+            for c in node.children:
+                names |= collect_leaves(c)
+            return names
+
+        child_map = {c.name: c for c in self._expanded.tree.children}
+        leaves = collect_leaves(child_map["RobotRoot_r0"])
+        assert "Move_r0" in leaves
+
+    def test_r0_subtree_has_no_r1_leaves(self):
+        def collect_leaves(node):
+            if node.node_type == 'leaf':
+                return {node.leaf_name}
+            names = set()
+            for c in node.children:
+                names |= collect_leaves(c)
+            return names
+
+        child_map = {c.name: c for c in self._expanded.tree.children}
+        leaves_r0 = collect_leaves(child_map["RobotRoot_r0"])
+        assert "AtGoal_r1" not in leaves_r0
+        assert "Move_r1" not in leaves_r0
+
+    def test_tree_text_has_parallel(self):
+        text = self._expanded.tree.to_tree_text(4)
+        assert "parallel" in text
+
+    def test_tree_text_contains_both_agent_subtrees(self):
+        text = self._expanded.tree.to_tree_text(4)
+        assert "RobotRoot_r0" in text
+        assert "RobotRoot_r1" in text
+
+    def test_tree_text_contains_leaf_references(self):
+        text = self._expanded.tree.to_tree_text(4)
+        assert "AtGoal_r0 {}" in text
+        assert "AtGoal_r1 {}" in text
+
+
+class TestExpanderSpecs:
+
+    @pytest.fixture(autouse=True)
+    def setup_expanded(self):
+        self._expanded = parse_and_expand(TWOROBOT1D_MULTIAGENT)
+
+    def test_total_spec_count_is_three(self):
+        # 1 INVARSPEC (inline) + 2 CTLSPECs (forall splits to one per agent)
+        assert len(self._expanded.specifications) == 3
+
+    def test_one_invarspec(self):
+        invars = [s for s in self._expanded.specifications if s.spec_type == "INVARSPEC"]
+        assert len(invars) == 1
+
+    def test_two_ctlspecs(self):
+        ctls = [s for s in self._expanded.specifications if s.spec_type == "CTLSPEC"]
+        assert len(ctls) == 2
+
+    def test_invarspec_no_forall_over_agents(self):
+        invars = [s for s in self._expanded.specifications if s.spec_type == "INVARSPEC"]
+        body = invars[0].body_text
+        assert "forall" not in body
+        assert "agents" not in body
+
+    def test_invarspec_contains_x_pos_r0(self):
+        invars = [s for s in self._expanded.specifications if s.spec_type == "INVARSPEC"]
+        assert "x_pos_r0" in invars[0].body_text
+
+    def test_invarspec_contains_x_pos_r1(self):
+        invars = [s for s in self._expanded.specifications if s.spec_type == "INVARSPEC"]
+        assert "x_pos_r1" in invars[0].body_text
+
+    def test_ctlspec_no_forall_over_agents(self):
+        for spec in self._expanded.specifications:
+            if spec.spec_type == "CTLSPEC":
+                assert "forall, i, agents" not in spec.body_text
+
+    def test_ctlspec_one_has_x_pos_r0(self):
+        ctls = [s for s in self._expanded.specifications if s.spec_type == "CTLSPEC"]
+        assert any("x_pos_r0" in s.body_text for s in ctls)
+
+    def test_ctlspec_one_has_x_pos_r1(self):
+        ctls = [s for s in self._expanded.specifications if s.spec_type == "CTLSPEC"]
+        assert any("x_pos_r1" in s.body_text for s in ctls)
+
+    def test_ctlspec_goal_x_not_literal(self):
+        for spec in self._expanded.specifications:
+            if spec.spec_type == "CTLSPEC":
+                assert "goal_x" not in spec.body_text
+
+    def test_ctlspec_contains_at_minus_one(self):
+        ctls = [s for s in self._expanded.specifications if s.spec_type == "CTLSPEC"]
+        assert any("at -1" in s.body_text for s in ctls)
+
+
+class TestMultiAgentScenarios:
+
+    def test_threeinarring_parses(self):
+        model = parse_tree_file(THREE_IN_RING)
+        assert model is not None
+        assert len(model.agent_types) == 1
+        assert len(model.agents) == 3
+
+    def test_threeinarring_expands_without_error(self):
+        expanded = parse_and_expand(THREE_IN_RING)
+        assert expanded is not None
+
+    def test_threeinarring_three_bl_vars(self):
+        expanded = parse_and_expand(THREE_IN_RING)
+        bl_names = {v.name for v in expanded.variables if v.scope == "bl"}
+        assert "act_r0" in bl_names
+        assert "act_r1" in bl_names
+        assert "act_r2" in bl_names
+
+    def test_threeinarring_three_env_vars(self):
+        expanded = parse_and_expand(THREE_IN_RING)
+        env_names = {v.name for v in expanded.variables if v.scope == "env"}
+        assert "x_pos_r0" in env_names
+        assert "x_pos_r1" in env_names
+        assert "x_pos_r2" in env_names
+
+    def test_threeinarring_parallel_has_three_children(self):
+        expanded = parse_and_expand(THREE_IN_RING)
+        assert expanded.tree.node_type == "parallel"
+        assert len(expanded.tree.children) == 3
+
+    def test_threeinarring_env_update_has_all_three_agents(self):
+        expanded = parse_and_expand(THREE_IN_RING)
+        text = expanded.environment_update_text
+        assert "x_pos_r0" in text
+        assert "x_pos_r1" in text
+        assert "x_pos_r2" in text
+
+    def test_threeinarring_env_update_no_index_loop(self):
+        expanded = parse_and_expand(THREE_IN_RING)
+        assert "x_pos[i]" not in expanded.environment_update_text
+
+    def test_threeinarring_invarspec_no_agent_names_as_tokens(self):
+        expanded = parse_and_expand(THREE_IN_RING)
+        invars = [s for s in expanded.specifications if s.spec_type == "INVARSPEC"]
+        assert len(invars) >= 1
+        body = invars[0].body_text
+        assert "forall" not in body
+
+    def test_threeinarring_ctlspecs_split_per_agent(self):
+        # 2 CTLSPECs in template × 3 agents = 6 CTLSPECs
+        expanded = parse_and_expand(THREE_IN_RING)
+        ctls = [s for s in expanded.specifications if s.spec_type == "CTLSPEC"]
+        assert len(ctls) == 6
+
+    def test_twodlivelock_parses(self):
+        model = parse_tree_file(TWOD_LIVELOCK)
+        assert model is not None
+        assert len(model.agents) == 2
+
+    def test_twodlivelock_expands_without_error(self):
+        expanded = parse_and_expand(TWOD_LIVELOCK)
+        assert expanded is not None
+
+    def test_twodlivelock_four_env_vars(self):
+        expanded = parse_and_expand(TWOD_LIVELOCK)
+        env_names = {v.name for v in expanded.variables if v.scope == "env"}
+        assert "x_pos_r0" in env_names
+        assert "x_pos_r1" in env_names
+        assert "y_pos_r0" in env_names
+        assert "y_pos_r1" in env_names
+
+    def test_twodlivelock_two_bl_vars(self):
+        expanded = parse_and_expand(TWOD_LIVELOCK)
+        bl_names = {v.name for v in expanded.variables if v.scope == "bl"}
+        assert "act_r0" in bl_names
+        assert "act_r1" in bl_names
+
+    def test_twodlivelock_parallel_has_two_children(self):
+        expanded = parse_and_expand(TWOD_LIVELOCK)
+        assert expanded.tree.node_type == "parallel"
+        assert len(expanded.tree.children) == 2
+
+    def test_twodlivelock_pathclear_checks_passed_through(self):
+        expanded = parse_and_expand(TWOD_LIVELOCK)
+        check_names = {ck.name for ck in expanded.environment_checks}
+        assert "PathClear_r0" in check_names
+        assert "PathClear_r1" in check_names
+
+    def test_twodlivelock_pathclear_condition_uses_flat_names(self):
+        expanded = parse_and_expand(TWOD_LIVELOCK)
+        ck_map = {ck.name: ck for ck in expanded.environment_checks}
+        cond = ck_map["PathClear_r0"].condition_text
+        assert "x_pos_r0" in cond
+        assert "x_pos_r1" in cond
+        assert "[r0]" not in cond
+        assert "[r1]" not in cond
+
+    def test_twodlivelock_env_update_has_y_pos_statements(self):
+        expanded = parse_and_expand(TWOD_LIVELOCK)
+        text = expanded.environment_update_text
+        assert "y_pos_r0" in text
+        assert "y_pos_r1" in text
+
+    def test_fiveinring_parses(self):
+        model = parse_tree_file(FIVE_IN_RING)
+        assert model is not None
+        assert len(model.agents) == 5
+
+    def test_fiveinring_expands_without_error(self):
+        expanded = parse_and_expand(FIVE_IN_RING)
+        assert expanded is not None
+
+    def test_fiveinring_five_bl_vars(self):
+        expanded = parse_and_expand(FIVE_IN_RING)
+        bl_names = {v.name for v in expanded.variables if v.scope == "bl"}
+        for agent in ["r0", "r1", "r2", "r3", "r4"]:
+            assert f"act_{agent}" in bl_names
+
+    def test_fiveinring_five_env_vars(self):
+        expanded = parse_and_expand(FIVE_IN_RING)
+        env_names = {v.name for v in expanded.variables if v.scope == "env"}
+        for agent in ["r0", "r1", "r2", "r3", "r4"]:
+            assert f"x_pos_{agent}" in env_names
+
+    def test_fiveinring_parallel_has_five_children(self):
+        expanded = parse_and_expand(FIVE_IN_RING)
+        assert expanded.tree.node_type == "parallel"
+        assert len(expanded.tree.children) == 5
+
+    def test_fiveinring_env_initial_values_distinct(self):
+        expanded = parse_and_expand(FIVE_IN_RING)
+        env_map = {v.name: v for v in expanded.variables if v.scope == "env"}
+        assert env_map["x_pos_r0"].initial_value == 0
+        assert env_map["x_pos_r1"].initial_value == 1
+        assert env_map["x_pos_r2"].initial_value == 2
+        assert env_map["x_pos_r3"].initial_value == 3
+        assert env_map["x_pos_r4"].initial_value == 4
+
+    def test_fiveinring_ctlspecs_split_per_agent(self):
+        # 2 CTLSPECs in template × 5 agents = 10 CTLSPECs
+        expanded = parse_and_expand(FIVE_IN_RING)
+        ctls = [s for s in expanded.specifications if s.spec_type == "CTLSPEC"]
+        assert len(ctls) == 10
+
+    def test_fiveinring_env_update_no_index_loop(self):
+        expanded = parse_and_expand(FIVE_IN_RING)
+        assert "x_pos[i]" not in expanded.environment_update_text
+
+
+class TestMaybeExpand:
+
+    def setup_method(self):
+        self.ae = _import_expander()
+
+    def test_returns_original_for_single_agent_file(self):
+        path = str(TWOROBOT1D_ORIGINAL)
+        result = self.ae.maybe_expand(path)
+        assert result == path
+
+    def test_returns_different_path_for_multiagent_file(self):
+        require_textx()
+        path = str(TWOROBOT1D_MULTIAGENT)
+        result = self.ae.maybe_expand(path)
+        assert result != path
+
+    def test_temp_file_exists_after_expansion(self):
+        require_textx()
+        path = str(TWOROBOT1D_MULTIAGENT)
+        result = self.ae.maybe_expand(path)
+        assert Path(result).exists()
+
+    def test_temp_file_has_tree_suffix(self):
+        require_textx()
+        path = str(TWOROBOT1D_MULTIAGENT)
+        result = self.ae.maybe_expand(path)
+        assert result.endswith(".tree")
+
+    def test_temp_file_is_parseable_by_standard_grammar(self):
+        require_textx()
+        path = str(TWOROBOT1D_MULTIAGENT)
+        result = self.ae.maybe_expand(path)
+        mm = load_metamodel()
+        model = mm.model_from_file(result)
+        assert model is not None
+
+    def test_temp_file_has_no_agent_types_section(self):
+        require_textx()
+        path = str(TWOROBOT1D_MULTIAGENT)
+        result = self.ae.maybe_expand(path)
+        content = Path(result).read_text()
+        assert "agent_types {" not in content
+        assert "agent_type {" not in content
+
+    def test_temp_file_has_no_agents_block(self):
+        require_textx()
+        path = str(TWOROBOT1D_MULTIAGENT)
+        result = self.ae.maybe_expand(path)
+        content = Path(result).read_text()
+        assert "\nagents {" not in content
+
+    def test_temp_file_has_no_array_syntax(self):
+        require_textx()
+        path = str(TWOROBOT1D_MULTIAGENT)
+        result = self.ae.maybe_expand(path)
+        content = Path(result).read_text()
+        assert "[agents]" not in content
+        assert "[self]" not in content
+
+    def test_temp_file_contains_expanded_var_names(self):
+        require_textx()
+        path = str(TWOROBOT1D_MULTIAGENT)
+        result = self.ae.maybe_expand(path)
+        content = Path(result).read_text()
+        assert "x_pos_r0" in content
+        assert "x_pos_r1" in content
+        assert "act_r0" in content
+        assert "act_r1" in content
+
+    def test_fallback_on_nonexistent_file(self):
+        path = "/nonexistent/does_not_exist.tree"
+        result = self.ae.maybe_expand(path)
+        assert result == path
+
+    def test_threeinarring_temp_file_is_parseable(self):
+        require_textx()
+        path = str(THREE_IN_RING)
+        result = self.ae.maybe_expand(path)
+        mm = load_metamodel()
+        model = mm.model_from_file(result)
+        assert model is not None
+
+    def test_fiveinring_temp_file_is_parseable(self):
+        require_textx()
+        path = str(FIVE_IN_RING)
+        result = self.ae.maybe_expand(path)
+        mm = load_metamodel()
+        model = mm.model_from_file(result)
+        assert model is not None
+
+    def test_twodlivelock_temp_file_is_parseable(self):
+        require_textx()
+        path = str(TWOD_LIVELOCK)
+        result = self.ae.maybe_expand(path)
+        mm = load_metamodel()
+        model = mm.model_from_file(result)
+        assert model is not None
+
+    def test_temp_file_standard_grammar_has_no_agent_types_attr(self):
+        require_textx()
+        path = str(TWOROBOT1D_MULTIAGENT)
+        result = self.ae.maybe_expand(path)
+        mm = load_metamodel()
+        model = mm.model_from_file(result)
+        agent_types = getattr(model, "agent_types", [])
+        assert len(agent_types) == 0

--- a/tests/multi_agent/test_string_helpers.py
+++ b/tests/multi_agent/test_string_helpers.py
@@ -1,0 +1,162 @@
+"""
+Pure unit tests for string manipulation and simplification helpers.
+
+Tests: _split_top_level, _extract_inner, _substitute,
+       _simplify_agent_identities, _simplify_implies, _remove_true_from_and
+"""
+
+from .conftest import _import_expander
+
+
+class TestStringHelpers:
+
+    def setup_method(self):
+        self.ae = _import_expander()
+
+    def test_split_top_level_simple(self):
+        parts = self.ae._split_top_level("a, b, c")
+        assert [p.strip() for p in parts] == ["a", "b", "c"]
+
+    def test_split_top_level_nested_parens(self):
+        parts = self.ae._split_top_level("a, (b, c), d")
+        stripped = [p.strip() for p in parts]
+        assert stripped == ["a", "(b, c)", "d"]
+
+    def test_split_top_level_deeply_nested(self):
+        parts = self.ae._split_top_level("forall, i, agents, (eq, x_pos[i], 0)")
+        stripped = [p.strip() for p in parts]
+        assert stripped[0] == "forall"
+        assert stripped[1] == "i"
+        assert stripped[2] == "agents"
+        assert "(eq, x_pos[i], 0)" in stripped[3]
+
+    def test_split_top_level_empty(self):
+        parts = self.ae._split_top_level("")
+        assert parts == [] or parts == [""]
+
+    def test_split_top_level_single_item(self):
+        parts = self.ae._split_top_level("x")
+        assert parts == ["x"]
+
+    def test_split_top_level_braces_not_counted(self):
+        parts = self.ae._split_top_level("a, {b, c}, d")
+        stripped = [p.strip() for p in parts]
+        assert stripped == ["a", "{b, c}", "d"]
+
+    def test_extract_inner_basic(self):
+        result = self.ae._extract_inner("(and, a, b)", 0)
+        assert result == "and, a, b"
+
+    def test_extract_inner_offset(self):
+        result = self.ae._extract_inner("xx(foo, bar)yy", 2)
+        assert result == "foo, bar"
+
+    def test_extract_inner_nested(self):
+        result = self.ae._extract_inner("(a, (b, c), d)", 0)
+        assert result == "a, (b, c), d"
+
+    def test_extract_inner_not_paren(self):
+        result = self.ae._extract_inner("no parens here", 0)
+        assert result is None
+
+    def test_extract_inner_unclosed(self):
+        result = self.ae._extract_inner("(unclosed", 0)
+        assert result is None
+
+    def test_substitute_basic(self):
+        result = self.ae._substitute("x_pos[self]", {"x_pos[self]": "x_pos_r0"})
+        assert result == "x_pos_r0"
+
+    def test_substitute_longest_first(self):
+        # Longer key "ab" must be substituted before shorter key "a".
+        # Without longest-first ordering, "a" on "ab" → "Yb", making "ab" never match.
+        subs = {"ab": "LONG", "a": "SHORT"}
+        result = self.ae._substitute("ab", subs)
+        assert result == "LONG"
+
+    def test_substitute_multiple_keys(self):
+        subs = {"x_pos[self]": "x_pos_r0", "act": "act_r0"}
+        result = self.ae._substitute("act and x_pos[self]", subs)
+        assert "act_r0" in result
+        assert "x_pos_r0" in result
+        assert "x_pos[self]" not in result
+
+    def test_substitute_no_match(self):
+        result = self.ae._substitute("hello world", {"foo": "bar"})
+        assert result == "hello world"
+
+    def test_substitute_empty_dict(self):
+        result = self.ae._substitute("some text", {})
+        assert result == "some text"
+
+
+class TestSimplification:
+
+    def setup_method(self):
+        self.ae = _import_expander()
+
+    def test_simplify_identities_eq_same_agent(self):
+        result = self.ae._simplify_agent_identities("(eq, r0, r0)", ["r0", "r1"])
+        assert result == "True"
+
+    def test_simplify_identities_eq_different_agents(self):
+        result = self.ae._simplify_agent_identities("(eq, r0, r1)", ["r0", "r1"])
+        assert result == "False"
+
+    def test_simplify_identities_neq_same_agent(self):
+        result = self.ae._simplify_agent_identities("(neq, r0, r0)", ["r0", "r1"])
+        assert result == "False"
+
+    def test_simplify_identities_neq_different_agents(self):
+        result = self.ae._simplify_agent_identities("(neq, r0, r1)", ["r0", "r1"])
+        assert result == "True"
+
+    def test_simplify_implies_true(self):
+        result = self.ae._simplify_implies("(implies, True, (eq, x, 0))")
+        assert result == "(eq, x, 0)"
+
+    def test_simplify_implies_false(self):
+        result = self.ae._simplify_implies("(implies, False, (eq, x, 0))")
+        assert result == "True"
+
+    def test_simplify_implies_no_match(self):
+        original = "(implies, (eq, a, b), (eq, x, 0))"
+        result = self.ae._simplify_implies(original)
+        assert result == original
+
+    def test_simplify_implies_plain_text_unchanged(self):
+        result = self.ae._simplify_implies("some plain text")
+        assert result == "some plain text"
+
+    def test_remove_true_from_and_leading(self):
+        result = self.ae._remove_true_from_and("(and, True, (eq, x, 0))")
+        assert result == "(eq, x, 0)"
+
+    def test_remove_true_from_and_trailing(self):
+        result = self.ae._remove_true_from_and("(and, (eq, x, 0), True)")
+        assert result == "(eq, x, 0)"
+
+    def test_remove_true_from_and_no_true(self):
+        original = "(and, (eq, a, 0), (eq, b, 1))"
+        result = self.ae._remove_true_from_and(original)
+        assert result == original
+
+    def test_simplify_full_chain_neq(self):
+        # (implies, (neq, r0, r1), BODY) → (implies, True, BODY) → BODY
+        text = "(implies, (neq, r0, r1), (neq, x_pos_r0, x_pos_r1))"
+        result = self.ae._simplify_agent_identities(text, ["r0", "r1"])
+        assert result == "(neq, x_pos_r0, x_pos_r1)"
+
+    def test_simplify_full_chain_same_agents_gives_true(self):
+        # (implies, (neq, r0, r0), BODY) → (implies, False, BODY) → True
+        text = "(implies, (neq, r0, r0), (neq, x_pos_r0, x_pos_r0))"
+        result = self.ae._simplify_agent_identities(text, ["r0", "r1"])
+        assert result == "True"
+
+    def test_simplify_three_agents_neq(self):
+        result = self.ae._simplify_agent_identities("(neq, r0, r2)", ["r0", "r1", "r2"])
+        assert result == "True"
+
+    def test_simplify_three_agents_eq_same(self):
+        result = self.ae._simplify_agent_identities("(eq, r1, r1)", ["r0", "r1", "r2"])
+        assert result == "True"

--- a/tests/test_multi_agent.py
+++ b/tests/test_multi_agent.py
@@ -1,0 +1,425 @@
+"""
+Tests for the multi-agent DSL extension (agent_types / agents).
+
+Test groups:
+  TestBackwardCompatibility  — existing single-agent files still work (pass now, must keep passing)
+  TestMultiAgentSyntaxParsing — grammar accepts agent_types/agents syntax (FAILS until Phase 1)
+  TestAgentExpander           — expander module exists and runs (FAILS until Phase 2)
+  TestExpanderEquivalence     — expanded output matches hand-written TwoRobot1D (FAILS until Phase 2)
+
+Run with:
+  python3 -m pytest tests/test_multi_agent.py -v
+  python3 -m pytest tests/test_multi_agent.py -v -k "Backward"  # only backward-compat tests
+"""
+
+import sys
+import pytest
+import tempfile
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).parent.parent
+SRC_PATH = REPO_ROOT / "src"
+if str(SRC_PATH) not in sys.path:
+    sys.path.insert(0, str(SRC_PATH))
+
+ORIG_MULTI_AGENT_DIR = REPO_ROOT / "examples" / "MultiAgent"
+MULTI_AGENT_DIR = REPO_ROOT / "test_examples" / "multi_agent"
+
+TWOROBOT1D_ORIGINAL = ORIG_MULTI_AGENT_DIR / "TwoRobot1D.tree"
+TWOROBOT1D_MULTIAGENT = MULTI_AGENT_DIR / "TwoRobot1D_multiagent.tree"
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def load_metamodel():
+    """Load the BehaVerify TextX metamodel. Skip test if unavailable."""
+    try:
+        from textx import metamodel_from_file
+    except ImportError:
+        pytest.skip("textx not installed")
+
+    try:
+        from importlib.resources import files
+        tx_file = files("behaverify").joinpath("data", "metamodel", "behaverify.tx")
+    except Exception:
+        tx_file = SRC_PATH / "behaverify" / "data" / "metamodel" / "behaverify.tx"
+
+    if not Path(str(tx_file)).exists():
+        pytest.skip("behaverify.tx metamodel not found")
+
+    return metamodel_from_file(str(tx_file))
+
+
+def parse_tree_file(path):
+    """Parse a .tree file and return the model, or skip if textx unavailable."""
+    mm = load_metamodel()
+    return mm.model_from_file(str(path))
+
+
+# ---------------------------------------------------------------------------
+# Group 1: Backward compatibility — must pass now and after implementation
+# ---------------------------------------------------------------------------
+
+class TestBackwardCompatibility:
+    """Existing single-agent files are unaffected by the extension."""
+
+    def test_original_tworobot1d_file_exists(self):
+        assert TWOROBOT1D_ORIGINAL.exists(), (
+            f"Reference file missing: {TWOROBOT1D_ORIGINAL}"
+        )
+
+    def test_original_tworobot1d_is_readable(self):
+        content = TWOROBOT1D_ORIGINAL.read_text()
+        assert len(content) > 0
+        assert "tree {" in content
+        assert "parallel" in content
+
+    def test_original_tworobot1d_has_expected_variables(self):
+        content = TWOROBOT1D_ORIGINAL.read_text()
+        # The hand-written file must have both robot variables
+        assert "act1" in content
+        assert "act2" in content
+        assert "x_d1" in content
+        assert "x_d2" in content
+
+    def test_original_tworobot1d_has_expected_checks(self):
+        content = TWOROBOT1D_ORIGINAL.read_text()
+        assert "AtGoal1" in content
+        assert "AtGoal2" in content
+
+    def test_original_tworobot1d_has_expected_actions(self):
+        content = TWOROBOT1D_ORIGINAL.read_text()
+        assert "Move1" in content
+        assert "Move2" in content
+
+    def test_original_tworobot1d_has_three_specs(self):
+        content = TWOROBOT1D_ORIGINAL.read_text()
+        # One INVARSPEC + two CTLSPECs
+        assert content.count("INVARSPEC") == 1
+        assert content.count("CTLSPEC") == 2
+
+    def test_original_tworobot1d_parses_with_current_grammar(self):
+        """The existing file must continue to parse after the grammar extension."""
+        model = parse_tree_file(TWOROBOT1D_ORIGINAL)
+        assert model is not None
+
+    def test_original_tworobot1d_generates_nuxmv(self):
+        """The existing pipeline must continue to generate SMV without errors."""
+        try:
+            from behaverify.behaverify import main
+        except ImportError:
+            pytest.skip("behaverify package not importable")
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            out = Path(tmpdir)
+            try:
+                main(["nuxmv", str(TWOROBOT1D_ORIGINAL), str(out),
+                      "--generate", "--overwrite"])
+                smv_files = list(out.rglob("*.smv"))
+                assert len(smv_files) == 1, (
+                    f"Expected 1 .smv file, got {len(smv_files)}"
+                )
+            except SystemExit as e:
+                if e.code != 0:
+                    pytest.fail(f"behaverify exited with code {e.code}")
+
+
+# ---------------------------------------------------------------------------
+# Group 2: Multi-agent syntax parsing — FAILS until Phase 1 (grammar extension)
+# ---------------------------------------------------------------------------
+
+class TestMultiAgentSyntaxParsing:
+    """
+    The multi-agent .tree file uses syntax not yet in the grammar.
+    These tests will FAIL until behaverify.tx is extended (Phase 1).
+    """
+
+    def test_multiagent_tree_file_exists(self):
+        """The test fixture file must exist regardless of grammar support."""
+        assert TWOROBOT1D_MULTIAGENT.exists(), (
+            f"Multi-agent test file missing: {TWOROBOT1D_MULTIAGENT}\n"
+            "Create it at test_examples/multi_agent/TwoRobot1D_multiagent.tree"
+        )
+
+    def test_multiagent_file_contains_agent_types_section(self):
+        content = TWOROBOT1D_MULTIAGENT.read_text()
+        assert "agent_types" in content, "File must contain agent_types section"
+        assert "agent_type" in content
+
+    def test_multiagent_file_contains_agents_section(self):
+        content = TWOROBOT1D_MULTIAGENT.read_text()
+        assert "agents {" in content, "File must contain agents section"
+
+    def test_multiagent_file_contains_parameters_block(self):
+        content = TWOROBOT1D_MULTIAGENT.read_text()
+        assert "parameters {" in content, "agent_type must declare parameters"
+        assert "goal_x" in content
+        assert "start_x" in content
+
+    def test_multiagent_file_contains_agent_instances_with_parameters(self):
+        content = TWOROBOT1D_MULTIAGENT.read_text()
+        assert "agent { r0 Robot" in content
+        assert "agent { r1 Robot" in content
+        assert "start_x :=" in content
+        assert "goal_x :=" in content
+
+    def test_multiagent_file_uses_env_array_syntax(self):
+        content = TWOROBOT1D_MULTIAGENT.read_text()
+        assert "x_pos[self]" in content, "Template should use x_pos[self] for own position"
+        assert "x_pos[i]" in content, "environment_update should use x_pos[i] iteration"
+
+    def test_multiagent_file_uses_forall_in_specs(self):
+        content = TWOROBOT1D_MULTIAGENT.read_text()
+        assert "forall" in content, "Specs should use forall quantifier over agents"
+
+    def test_grammar_accepts_agent_types_syntax(self):
+        """
+        After Phase 1 grammar extension: the grammar accepts agent_types/agents syntax.
+        """
+        mm = load_metamodel()
+        model = mm.model_from_file(str(TWOROBOT1D_MULTIAGENT))
+        assert model is not None
+        assert len(model.agent_types) > 0, "Parsed model should have agent_types"
+        assert len(model.agents) > 0, "Parsed model should have agents"
+
+    def test_extended_grammar_accepts_agent_types_syntax(self):
+        """
+        AFTER Phase 1: the extended grammar should parse the file without error.
+        Currently expected to fail.
+        """
+        # This will fail until behaverify.tx is extended
+        model = parse_tree_file(TWOROBOT1D_MULTIAGENT)
+        assert model is not None
+        assert hasattr(model, "agent_types"), (
+            "Parsed model should have agent_types attribute"
+        )
+        assert hasattr(model, "agents"), (
+            "Parsed model should have agents attribute"
+        )
+
+    def test_extended_grammar_parses_agent_parameters(self):
+        """After Phase 1: agent_type must expose its parameters."""
+        model = parse_tree_file(TWOROBOT1D_MULTIAGENT)
+        assert len(model.agent_types) == 1
+        robot_type = model.agent_types[0]
+        param_names = [p.name for p in robot_type.parameters]
+        assert "start_x" in param_names
+        assert "goal_x" in param_names
+
+    def test_extended_grammar_parses_agent_instances(self):
+        """After Phase 1: agents block exposes two instances with parameter values."""
+        model = parse_tree_file(TWOROBOT1D_MULTIAGENT)
+        assert len(model.agents) == 2
+        names = [a.name for a in model.agents]
+        assert "r0" in names
+        assert "r1" in names
+
+
+# ---------------------------------------------------------------------------
+# Group 3: Expander module — FAILS until Phase 2 (agent_expander.py created)
+# ---------------------------------------------------------------------------
+
+class TestAgentExpander:
+    """
+    Tests for src/behaverify/agent_expander.py.
+    All will FAIL with ImportError until Phase 2 is implemented.
+    """
+
+    def test_agent_expander_module_importable(self):
+        """Phase 2 must create src/behaverify/agent_expander.py."""
+        from behaverify.agent_expander import expand_agents  # noqa: F401
+
+    def test_expander_accepts_parsed_model(self):
+        from behaverify.agent_expander import expand_agents
+        model = parse_tree_file(TWOROBOT1D_MULTIAGENT)
+        expanded = expand_agents(model)
+        assert expanded is not None
+
+    def test_expander_produces_two_bl_variables(self):
+        """act_r0 and act_r1 must appear in expanded variables."""
+        from behaverify.agent_expander import expand_agents
+        model = parse_tree_file(TWOROBOT1D_MULTIAGENT)
+        expanded = expand_agents(model)
+
+        bl_names = [v.name for v in expanded.variables if v.scope == "bl"]
+        assert "act_r0" in bl_names, f"act_r0 missing from bl vars: {bl_names}"
+        assert "act_r1" in bl_names, f"act_r1 missing from bl vars: {bl_names}"
+
+    def test_expander_produces_two_env_variables(self):
+        """x_pos_r0 and x_pos_r1 must appear in expanded env variables."""
+        from behaverify.agent_expander import expand_agents
+        model = parse_tree_file(TWOROBOT1D_MULTIAGENT)
+        expanded = expand_agents(model)
+
+        env_names = [v.name for v in expanded.variables if v.scope == "env"]
+        assert "x_pos_r0" in env_names, f"x_pos_r0 missing from env vars: {env_names}"
+        assert "x_pos_r1" in env_names, f"x_pos_r1 missing from env vars: {env_names}"
+
+    def test_expander_initialises_env_vars_from_parameters(self):
+        """x_pos_r0 initial value must match r0.start_x (= min_val = 0)."""
+        from behaverify.agent_expander import expand_agents
+        model = parse_tree_file(TWOROBOT1D_MULTIAGENT)
+        expanded = expand_agents(model)
+
+        env_map = {v.name: v for v in expanded.variables if v.scope == "env"}
+        # r0.start_x = min_val = 0, r1.start_x = max_val = 4
+        assert env_map["x_pos_r0"].initial_value == 0, (
+            "x_pos_r0 should initialise to 0 (r0.start_x = min_val)"
+        )
+        assert env_map["x_pos_r1"].initial_value == 4, (
+            "x_pos_r1 should initialise to 4 (r1.start_x = max_val)"
+        )
+
+    def test_expander_produces_atgoal_checks_with_substituted_goals(self):
+        """AtGoal_r0 condition must use max_val (r0.goal_x); AtGoal_r1 must use min_val."""
+        from behaverify.agent_expander import expand_agents
+        model = parse_tree_file(TWOROBOT1D_MULTIAGENT)
+        expanded = expand_agents(model)
+
+        check_names = [c.name for c in expanded.environment_checks]
+        assert "AtGoal_r0" in check_names
+        assert "AtGoal_r1" in check_names
+
+    def test_expander_produces_move_actions_per_agent(self):
+        from behaverify.agent_expander import expand_agents
+        model = parse_tree_file(TWOROBOT1D_MULTIAGENT)
+        expanded = expand_agents(model)
+
+        action_names = [a.name for a in expanded.action_nodes]
+        assert "Move_r0" in action_names
+        assert "Move_r1" in action_names
+
+    def test_expander_produces_parallel_root(self):
+        """Expanded tree root must be a parallel node."""
+        from behaverify.agent_expander import expand_agents
+        model = parse_tree_file(TWOROBOT1D_MULTIAGENT)
+        expanded = expand_agents(model)
+
+        root = expanded.tree
+        assert root.node_type == "parallel", (
+            f"Root should be parallel, got {root.node_type}"
+        )
+
+    def test_expander_produces_two_subtrees_under_parallel_root(self):
+        from behaverify.agent_expander import expand_agents
+        model = parse_tree_file(TWOROBOT1D_MULTIAGENT)
+        expanded = expand_agents(model)
+
+        assert len(expanded.tree.children) == 2, (
+            f"Expected 2 agent subtrees, got {len(expanded.tree.children)}"
+        )
+
+    def test_expander_expands_forall_specs_to_concrete_agents(self):
+        """After expansion, no spec should contain a forall quantifier over agents."""
+        from behaverify.agent_expander import expand_agents
+        import re
+        model = parse_tree_file(TWOROBOT1D_MULTIAGENT)
+        expanded = expand_agents(model)
+
+        # Serialize specs to string and check no unresolved forall remains
+        # (exact serialisation depends on implementation; adapt as needed)
+        for spec in expanded.specifications:
+            spec_str = str(spec)
+            assert "forall" not in spec_str or "agents" not in spec_str, (
+                f"Spec still contains unresolved forall: {spec_str}"
+            )
+
+    def test_expander_produces_no_agent_types_in_expanded_model(self):
+        """Expanded model should have no agent_types — they are consumed by the expander."""
+        from behaverify.agent_expander import expand_agents
+        model = parse_tree_file(TWOROBOT1D_MULTIAGENT)
+        expanded = expand_agents(model)
+
+        agent_types = getattr(expanded, "agent_types", [])
+        assert len(agent_types) == 0, (
+            "Expanded model should have no agent_types remaining"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Group 4: Equivalence with hand-written TwoRobot1D — FAILS until Phase 2
+# ---------------------------------------------------------------------------
+
+class TestExpanderEquivalence:
+    """
+    The expanded multi-agent model should produce SMV equivalent to TwoRobot1D.tree.
+    These tests run both files through the full pipeline and compare generated output.
+    """
+
+    @pytest.fixture
+    def expanded_smv(self, tmp_path):
+        """Generate SMV from the expanded multi-agent file."""
+        from behaverify.agent_expander import expand_agents
+        from behaverify.behaverify import main
+
+        model = parse_tree_file(TWOROBOT1D_MULTIAGENT)
+        expanded = expand_agents(model)
+
+        # Write the expanded model to a temp .tree file and run the pipeline
+        expanded_tree_path = tmp_path / "expanded.tree"
+        from behaverify.agent_expander import model_to_tree_text
+        expanded_tree_path.write_text(model_to_tree_text(expanded))
+
+        out = tmp_path / "expanded_out"
+        out.mkdir()
+        main(["nuxmv", str(expanded_tree_path), str(out), "--generate", "--overwrite"])
+        smv_files = list(out.rglob("*.smv"))
+        assert len(smv_files) == 1
+        return smv_files[0].read_text()
+
+    @pytest.fixture
+    def original_smv(self, tmp_path):
+        """Generate SMV from the original hand-written TwoRobot1D.tree."""
+        from behaverify.behaverify import main
+
+        out = tmp_path / "original_out"
+        out.mkdir()
+        main(["nuxmv", str(TWOROBOT1D_ORIGINAL), str(out), "--generate", "--overwrite"])
+        smv_files = list(out.rglob("*.smv"))
+        assert len(smv_files) == 1
+        return smv_files[0].read_text()
+
+    def test_both_smv_files_generated(self, expanded_smv, original_smv):
+        """Sanity check: both pipelines produce non-empty SMV output."""
+        assert len(expanded_smv) > 0
+        assert len(original_smv) > 0
+
+    def test_expanded_smv_has_same_number_of_var_declarations(
+        self, expanded_smv, original_smv
+    ):
+        """Both SMV files should declare the same number of VAR sections."""
+        expanded_vars = expanded_smv.count("VAR")
+        original_vars = original_smv.count("VAR")
+        assert expanded_vars == original_vars, (
+            f"VAR count differs: expanded={expanded_vars}, original={original_vars}"
+        )
+
+    def test_expanded_smv_has_same_number_of_specs(self, expanded_smv, original_smv):
+        """Both SMV files should have the same number of INVARSPEC / CTLSPEC entries."""
+        for spec_type in ("INVARSPEC", "CTLSPEC", "LTLSPEC"):
+            exp_count = expanded_smv.count(spec_type)
+            orig_count = original_smv.count(spec_type)
+            assert exp_count == orig_count, (
+                f"{spec_type} count differs: expanded={exp_count}, original={orig_count}"
+            )
+
+    def test_expanded_smv_has_parallel_module(self, expanded_smv, original_smv):
+        """Both SMV files must contain a parallel composite module."""
+        assert "parallel" in expanded_smv.lower()
+        assert "parallel" in original_smv.lower()
+
+    def test_expanded_smv_contains_two_agent_act_variables(self, expanded_smv):
+        """The generated SMV must have action variables for both agents."""
+        # Variable names will be act_r0/act_r1 in expanded vs act1/act2 in original
+        assert "act_r0" in expanded_smv or "act_r1" in expanded_smv, (
+            "Expanded SMV should reference agent action variables"
+        )
+
+    def test_original_smv_contains_original_variable_names(self, original_smv):
+        """The original SMV must still use the hand-written variable names."""
+        assert "act1" in original_smv
+        assert "act2" in original_smv
+        assert "x_d1" in original_smv
+        assert "x_d2" in original_smv


### PR DESCRIPTION
- Modified `src/behaverify/data/metamodel/behaverify.tx` to extend grammar with `agent_types` and `agent` blocks, `[agent]` array specifer, index variable references, and `forall`/`exists` quantifiers
- Added `src/behaverify/agent_expander.py` that expands multi-agent tree files into flat single-agent tree files
- Modified `src/behaverify/behaverify.py` to check if multi-agent expansion is needed prior to code generation
- Added new multi-agent scenarios in `examples/MultiAgent` and `test_examples/multi_agent`
- Added new tests: `tests/multi_agent` and `tests/test_multi_agent.py`