### PR TITLE
Fix Sphinx -W docs build

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -37,10 +37,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.12'
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -23,7 +23,7 @@ docs\make.bat html
 ## Landing-page pipeline figure
 
 Authored in TikZ at `_static/tikz/pipeline.tex`; rendered artefacts
-(`_static/img/pipeline.svg` / `.png`) are committed so the Sphinx build
+(`_static/img/pipeline.png`) are committed so the Sphinx build
 does not require a TeX installation. To regenerate after editing the
 `.tex` source, run `make -C docs tikz`.
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -64,6 +64,7 @@ exclude_patterns = [
     "**/README.md",
     "_templates/.gitkeep",
     "_static/tikz",  # raw TeX source, not docs content
+    "DEPLOYMENT.md",  # maintainer-only doc, intentionally not in any toctree
 ]
 
 suppress_warnings = [

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -8,7 +8,7 @@ BehaVerify: Formal Verification for Behavior Trees
    runtime, and a publication-quality diagram --- from a single
    ``.tree`` source file.
 
-.. image:: _static/img/pipeline.svg
+.. image:: _static/img/pipeline.png
    :alt: BehaVerify end-to-end pipeline: inputs (.tree, .onnx, .smv)
          flow through a TextX parser, model builder, and internal IR;
          the IR is lowered by six code generators (nuxmv, python, cpp,

--- a/docs/theory/behavior-trees.rst
+++ b/docs/theory/behavior-trees.rst
@@ -83,7 +83,7 @@ turn below.
 Sequence
 ^^^^^^^^
 
-.. figure:: /_static/img/bt-sequence.svg
+.. figure:: /_static/img/bt-sequence.png
    :alt: A Sequence composite with three children; the first two are
          conditions (ovals), the third an action (rectangle).
    :class: pipeline-hero
@@ -101,7 +101,7 @@ classical conjunctions of pre-condition checks followed by an action
 Selector (Fallback)
 ^^^^^^^^^^^^^^^^^^^
 
-.. figure:: /_static/img/bt-selector.svg
+.. figure:: /_static/img/bt-selector.png
    :alt: A Selector composite with two condition children and one
          action child.
    :class: pipeline-hero
@@ -117,7 +117,7 @@ strategies (e.g. *try A, else try B, else fail*).
 Parallel
 ^^^^^^^^
 
-.. figure:: /_static/img/bt-parallel.svg
+.. figure:: /_static/img/bt-parallel.png
    :alt: A Parallel composite with two condition children and one
          action child that all tick together.
    :class: pipeline-hero
@@ -155,7 +155,7 @@ control how often it is ticked. BehaVerify's DSL supports four kinds.
 Inverter
 ^^^^^^^^
 
-.. figure:: /_static/img/bt-inverter.svg
+.. figure:: /_static/img/bt-inverter.png
    :alt: An inverter decorator with a single child node.
    :class: pipeline-hero
    :width: 28%
@@ -169,7 +169,7 @@ decorator is well-defined on non-terminating children.
 Repeat (N)
 ^^^^^^^^^^
 
-.. figure:: /_static/img/bt-repeat.svg
+.. figure:: /_static/img/bt-repeat.png
    :alt: A repeat(N) decorator with a single child node.
    :class: pipeline-hero
    :width: 28%
@@ -183,7 +183,7 @@ early and is returned as the decorator's own status.
 Status override (X_is_Y)
 ^^^^^^^^^^^^^^^^^^^^^^^^
 
-.. figure:: /_static/img/bt-xisy.svg
+.. figure:: /_static/img/bt-xisy.png
    :alt: An X_is_Y status-override decorator with a single child node.
    :class: pipeline-hero
    :width: 28%
@@ -198,7 +198,7 @@ pick any :math:`X, Y \in \{\mathrm{SUCCESS}, \mathrm{FAILURE},
 One-shot
 ^^^^^^^^
 
-.. figure:: /_static/img/bt-oneshot.svg
+.. figure:: /_static/img/bt-oneshot.png
    :alt: A one-shot decorator with a single child node.
    :class: pipeline-hero
    :width: 28%
@@ -235,7 +235,7 @@ on different blackboard states. Numbers on the top-right of each
 evaluated child mark the evaluation order; greyed children were
 skipped by the selector's short-circuit rule.
 
-.. figure:: /_static/img/bt-tick-example.svg
+.. figure:: /_static/img/bt-tick-example.png
    :alt: Three consecutive ticks of a selector tree, numbering the
          evaluation order and colouring each visited node by its
          per-tick status.

--- a/docs/theory/bt-to-smv.rst
+++ b/docs/theory/bt-to-smv.rst
@@ -11,7 +11,7 @@ Behavior Tree → SMV Translation
 Encoding at a glance
 --------------------
 
-.. figure:: /_static/img/encoding-naive.svg
+.. figure:: /_static/img/encoding-naive.png
    :alt: Naive encoding: six SMV transitions encode one BT tick.
    :class: pipeline-hero
    :width: 95%
@@ -20,7 +20,7 @@ Encoding at a glance
    ticking each child, bubbling statuses up, updating the
    blackboard --- is its own SMV transition.
 
-.. figure:: /_static/img/encoding-ff.svg
+.. figure:: /_static/img/encoding-ff.png
    :alt: Fast-forwarding encoding: one SMV transition encodes one BT tick.
    :class: pipeline-hero
    :width: 70%

--- a/docs/theory/soundness.rst
+++ b/docs/theory/soundness.rst
@@ -41,7 +41,7 @@ verifies:
 
 The chain decomposes as:
 
-.. figure:: /_static/img/soundness-chain.svg
+.. figure:: /_static/img/soundness-chain.png
    :alt: Soundness chain from .tree to T models phi with five numbered
          claims labelling each preservation step.
    :class: pipeline-hero


### PR DESCRIPTION
The strict (`-W`) docs build was failing on 13 warnings:

- 12 image-not-readable warnings for `_static/img/*.svg` files that were never committed (the root `.gitignore` excludes `*.svg`). The corresponding `.png` renders are present in `docs/_static/img/` and are adequate.
- 1 toctree warning for `docs/DEPLOYMENT.md`, a maintainer-only doc not meant to appear in the user-facing nav.

## Changes

- `docs/index.rst`, `docs/theory/behavior-trees.rst`, `docs/theory/bt-to-smv.rst`, `docs/theory/soundness.rst` — switch 12 `.svg` image references to the committed `.png` renders.
- `docs/conf.py` — add `DEPLOYMENT.md` to `exclude_patterns`.
- `docs/README.md` — drop the `pipeline.svg` mention (only `.png` is committed).
- `.github/workflows/docs.yml` — bump `actions/checkout@v4` → `@v5` and `actions/setup-python@v5` → `@v6` to clear the Node 20 deprecation warning.

## Verification

```
sphinx-build -b html -W --keep-going -n docs docs/_build/html
```
should now print `build succeeded` instead of `build finished with problems, 13 warnings`.